### PR TITLE
refactor: dedupe MODEL_ID assignment and import logging (#3)

### DIFF
--- a/GeminiDiscordBot.py
+++ b/GeminiDiscordBot.py
@@ -25,7 +25,6 @@ image_chat = {}
 load_dotenv()
 
 MODEL_ID = os.getenv("MODEL_ID")
-MODEL_ID = os.getenv("MODEL_ID")
 # IMAGEN_MODEL = os.getenv("IMAGEN_MODEL") # Deprecated
 GEMINI_IMAGE_MODEL = os.getenv("GEMINI_IMAGE_MODEL", "gemini-2.5-flash-image")
 
@@ -333,7 +332,6 @@ async def save_response_as_file(message, response_text):
 
 #################
 from typing import Any
-import logging
 
 
 def process_answer(answer: Any) -> str:
@@ -793,9 +791,6 @@ async def split_and_send_messages(message_system, text, max_length):
 
         await message_system.channel.send(text[start:end].strip())
         start = end
-
-
-import logging
 
 
 # Removed old generate_image function


### PR DESCRIPTION
## Summary
- `MODEL_ID = os.getenv("MODEL_ID")` が先頭で 2 行連続していた重複を 1 行に集約
- `import logging` が 3 箇所（ファイル先頭・`process_answer` 前・画像生成ヘルパー前）に書かれていた重複を先頭 1 箇所に集約
- 挙動変更なし、5 行削除

## Test plan
- [x] `python -m py_compile GeminiDiscordBot.py` で構文検証済み
- [x] `^import logging` は 1 箇所のみ、`^MODEL_ID = os\.getenv` も 1 箇所のみ（grep 確認）
- [x] `logging.xxx` の呼び出しは全て先頭の import から解決される（モジュールスコープが維持されている）
- [ ] 実機で通常応答・`!save`・`!img`・`!edit` が従来どおり動作することを手動確認

## スコープ外
- `from typing import Any`（L335 相当）のファイル先頭集約は #3 の対象外のため未実施
- その他のレビュー指摘事項

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)