### PR TITLE
docs: document safety-OFF and open access risk in README (#6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,15 @@ Gemini Discord Bot allows you to converse on Discord using Google's Gemini API. 
 
 ---
 
+## Security Considerations
+
+**Safety filters are disabled by default.** In `GeminiDiscordBot.py`, all four Gemini safety categories (`HARM_CATEGORY_HATE_SPEECH`, `HARM_CATEGORY_DANGEROUS_CONTENT`, `HARM_CATEGORY_SEXUALLY_EXPLICIT`, `HARM_CATEGORY_HARASSMENT`) are configured with `threshold="OFF"` in `generate_content_config`. Combined with an open access list, this lets anyone who can message the bot generate content that would otherwise be filtered.
+
+- **Always set `ALLOWED_USER_IDS` for any non-private deployment.** When it is empty, the startup log prints `Warning: No ALLOWED_USER_IDS set. Bot will respond to everyone.` — treat this as a deployment blocker unless the bot is truly private.
+- To re-enable moderation, edit `generate_content_config` in `GeminiDiscordBot.py` and raise the thresholds (for example, `threshold="BLOCK_MEDIUM_AND_ABOVE"`). Refer to the [Gemini API safety settings documentation](https://ai.google.dev/gemini-api/docs/safety-settings) for the available values.
+
+---
+
 ## Important Notes
 
 - The Google AI Studio API has usage limits and may incur charges beyond the free tier. Refer to the [Google AI Studio documentation](https://makersuite.google.com/) for pricing details.


### PR DESCRIPTION
## Summary
- README に "Security Considerations" セクションを追加
- 既定で Gemini の safety_settings 全 4 カテゴリが `threshold="OFF"` である旨を明記
- `ALLOWED_USER_IDS` 未設定時のリスク（全開放 → 誰でもフィルタ無効の AI を利用可）と「非プライベート運用では必ず設定せよ」の指針を追記
- モデレーションを有効化したい場合の具体的な手順と Gemini 公式ドキュメントへのリンクを追加

## 差分
README のみ（コード変更なし）、9 行追加。

## スコープ外
- Issue 本文で「任意」とされていた起動時の強い警告出力（safety OFF + `ALLOWED_USER_IDS` 空のとき）は別 Issue として扱う
- 他のレビュー指摘事項

## Test plan
- [x] README を GitHub 上のプレビューで読める構造になっていること（既存の `---` 区切りセクションに挿入）
- [ ] 実機での動作確認は不要（ドキュメントのみ）

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)