### PR TITLE
refactor: replace print-in-except with logging.exception (#7)

### DIFF
--- a/GeminiDiscordBot.py
+++ b/GeminiDiscordBot.py
@@ -274,8 +274,10 @@ async def process_attachments(message, cleaned_text, save_to_file=False):
                 mime_type = get_mime_type_from_bytes(file_data)
                 files_data.append({"data": file_data, "mime_type": mime_type})
         except aiohttp.ClientError as e:
+            logging.exception("Failed to download attachment %s", attachment.filename)
             await message.channel.send(f"Failed to download the file {attachment.filename}: {e}")
         except Exception as e:
+            logging.exception("Unexpected error while downloading attachment %s", attachment.filename)
             await message.channel.send(f"An unexpected error occurred with {attachment.filename}: {e}")
 
     if not files_data:
@@ -296,6 +298,7 @@ async def process_attachments(message, cleaned_text, save_to_file=False):
                 message, response_text, MAX_DISCORD_LENGTH
             )
     except Exception as e:
+        logging.exception("Unexpected error during response generation for attachments")
         await message.channel.send(f"An unexpected error occurred during generation: {e}")
 
 
@@ -445,8 +448,8 @@ async def generate_response_with_text(message, cleaned_text):
     try:
         answer = await chat_session.send_message(cleaned_text)
         return process_answer(answer)
-    except Exception as e:
-        print(f"An error occurred: {e}")
+    except Exception:
+        logging.exception("Error in generate_response_with_text for user %s", user_id)
         return "An error occurred while generating the response."
 
 
@@ -477,8 +480,8 @@ async def generate_response_with_files_and_text(message, files, text):
         answer = await chat_session.send_message(prompt_parts)
         return process_answer(answer)
 
-    except Exception as e:
-        print(f"An error occurred: {e}")
+    except Exception:
+        logging.exception("Error in generate_response_with_files_and_text for user %s", user_id)
         return "An error occurred while generating the response."
 
 


### PR DESCRIPTION
## Summary
- `generate_response_with_text` と `generate_response_with_files_and_text` の `except Exception as e: print(f"An error occurred: {e}")` を `logging.exception(...)` に置換。トレースバックが保持される
- `process_attachments` の 3 つの except 句（aiohttp.ClientError / Exception x2）は従来 `channel.send` のみで何もログに残っていなかった。各句に `logging.exception(...)` を併置
- ユーザー向けの `channel.send(...)` は維持
- 挙動変更なし（ログ出力の詳細化のみ）

## スコープ内
- エラー出力の `print(...)` → `logging.exception(...)` 置換
- トレース落としの `except Exception: channel.send(...)` 4 箇所への `logging.exception` 追加

## スコープ外（Issue 方針通り）
- 起動バナー系の `print(...)`（`on_ready` / `Image commands enabled: ...` / `Allowed user IDs: ...` 等）はエラーハンドリングではないため対象外
- 既に `logging.error(f"...: {e}")` を使っている箇所（save_debug_file / dropbox / gdrive / generate_image_session / download_attachments_as_parts / update_text_chat_with_image）の `.exception` 化は別改善として見送り

## Test plan
- [x] `python -m py_compile GeminiDiscordBot.py` で構文検証済み
- [x] `print(f"An error occurred` の残存なし（grep で 0 件）
- [ ] 実機で以下の動作を確認
  - [ ] 通常テキスト応答が成功する（回帰なし）
  - [ ] 意図的にエラーを起こす（例: 破損ファイル添付）→ トレースバックが標準ログに出ていること
  - [ ] `bot_usage.log`（アクセスログ）が従来どおり分離されていること

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)