### PR TITLE
fix: use snake_case for grounding_metadata attributes (#8)

### DIFF
--- a/GeminiDiscordBot.py
+++ b/GeminiDiscordBot.py
@@ -400,10 +400,10 @@ def process_answer(answer: Any) -> str:
                     return "\n".join(candidate_text_parts).strip()
 
             # Optionally, log the grounding metadata if available.
-            if hasattr(candidate, "groundingMetadata") and candidate.groundingMetadata:
+            if hasattr(candidate, "grounding_metadata") and candidate.grounding_metadata:
                 logging.info(
                     "Grounding metadata (rendered content): %s",
-                    candidate.groundingMetadata.searchEntryPoint.renderedContent,
+                    candidate.grounding_metadata.search_entry_point.rendered_content,
                 )
 
         # If no meaningful text is found, log the entire answer object.


### PR DESCRIPTION
## Summary
- `process_answer` 内で `candidate.groundingMetadata` / `searchEntryPoint` / `renderedContent` と camelCase で参照していたが、google-genai Python SDK は snake_case を公開している
- 結果として `hasattr(candidate, "groundingMetadata")` が常に False となり、grounding ログのブランチはデッドコードだった
- 3 属性すべてを snake_case に修正（`grounding_metadata` / `search_entry_point` / `rendered_content`）

## 変更範囲
`GeminiDiscordBot.py` の 2 行変更のみ。

## 注意点
この修正によって、これまで一度も実行されていなかったコードパスが実際に発火するようになる。テキスト応答が空でかつ Google 検索グラウンディングが付いた場合に該当。SDK が `search_entry_point` を None で返す実装だった場合は別途 AttributeError の可能性があるが、既存挙動に対する改善なので、まず動作確認の上で必要なら別 Issue として追加ガードを検討する方針。

## Test plan
- [x] `python -m py_compile GeminiDiscordBot.py` で構文検証済み
- [x] camelCase 参照の残存なし（`groundingMetadata` / `searchEntryPoint` / `renderedContent` すべて 0 件）
- [ ] 実機で Google 検索グラウンディングが発火するプロンプト（例: 時事的な質問）を投げて、`Grounding metadata (rendered content): ...` のログが出ることを確認
- [ ] 既存の通常応答が回帰していないこと

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)