### PR TITLE
feat: validate aspect_ratio with whitelist in parse_args (#9)

### DIFF
--- a/GeminiDiscordBot.py
+++ b/GeminiDiscordBot.py
@@ -39,6 +39,10 @@ GCP_REGION = os.getenv("GCP_REGION")
 # The maximum number of characters per Discord message
 MAX_DISCORD_LENGTH = 2000
 
+# Supported aspect ratios for Gemini image generation
+SUPPORTED_ASPECT_RATIOS = frozenset({"1:1", "16:9", "9:16", "4:3", "3:4"})
+DEFAULT_ASPECT_RATIO = "1:1"
+
 # Load the environment variable for enabling/disabling commands
 IMG_COMMANDS_ENABLED = os.getenv("IMG_COMMANDS_ENABLED", "False").lower() == "true"
 print(f"Image commands enabled: {IMG_COMMANDS_ENABLED}")
@@ -233,7 +237,13 @@ async def on_message(message):
             elif img_command:
                 await message.add_reaction("🎨")
                 # Process !img command
-                prompt_text, aspect_ratio = await parse_args(prompt_text)
+                prompt_text, aspect_ratio, invalid_ratio = await parse_args(prompt_text)
+                if invalid_ratio is not None:
+                    supported = ", ".join(sorted(SUPPORTED_ASPECT_RATIOS))
+                    await message.channel.send(
+                        f"Unsupported aspect_ratio `{invalid_ratio}`. "
+                        f"Supported values: {supported}. Falling back to `{DEFAULT_ASPECT_RATIO}`."
+                    )
                 await message.channel.send(f"Prompt: {prompt_text}")
                 await handle_generation(message, prompt_text, aspect_ratio)
 
@@ -903,16 +913,26 @@ async def handle_edit_generation(message, prompt):
 
 
 async def parse_args(args):
-    """
-    Parses arguments for image generation.
+    """Parses arguments for image generation.
+
     Expected format: prompt | aspect_ratio
+
+    Returns:
+        (prompt, aspect_ratio, invalid_ratio) where invalid_ratio is None
+        when the ratio is supported or omitted, and is the original input
+        string otherwise (so the caller can notify the user).
     """
     parts = [part.strip() for part in args.split("|")]
     prompt = parts[0] if len(parts) > 0 else ""
-    aspect_ratio = "1:1" # Default to 1:1 as it is standard, or keep 16:9 if preferred
-    if len(parts) > 1:
-        aspect_ratio = parts[1]
-    return prompt, aspect_ratio
+    aspect_ratio = DEFAULT_ASPECT_RATIO
+    invalid_ratio = None
+    if len(parts) > 1 and parts[1]:
+        requested = parts[1]
+        if requested in SUPPORTED_ASPECT_RATIOS:
+            aspect_ratio = requested
+        else:
+            invalid_ratio = requested
+    return prompt, aspect_ratio, invalid_ratio
 
 async def download_attachments_as_parts(message):
     """Downloads attachments and returns them as a list of types.Part."""


### PR DESCRIPTION
## Summary
- モジュール定数 `SUPPORTED_ASPECT_RATIOS = {1:1, 16:9, 9:16, 4:3, 3:4}` と `DEFAULT_ASPECT_RATIO = "1:1"` を追加
- `parse_args` の戻り値を `(prompt, aspect_ratio)` → `(prompt, aspect_ratio, invalid_ratio)` の 3-tuple に拡張。不正値が渡された場合は `aspect_ratio` をデフォルトにフォールバックし、元の入力値を `invalid_ratio` で返す
- `on_message` の `!img` 分岐で `invalid_ratio` が非 None のとき、サポート値の一覧とフォールバック先をチャンネルに通知
- Issue 本文の対応方針に準拠

## なぜ 3-tuple にしたか
`parse_args` を純粋なパーサとして残したまま、バリデーション結果の「通知責務」だけを呼び出し側に委ねる設計。`parse_args` 自体から `message.channel.send` を呼ばないので、テストや将来の再利用が容易。

## ホワイトリスト値について
Gemini 画像モデルがサポートする一般的な 5 値（`1:1`, `16:9`, `9:16`, `4:3`, `3:4`）を採用。モデル側でさらに値が追加された場合はこの定数を更新する運用。

## Test plan
- [x] `python -m py_compile GeminiDiscordBot.py` で構文検証済み
- [x] `parse_args` の呼び出し元は `on_message` の 1 箇所のみ、3-tuple unpack に更新済み
- [ ] 実機で以下を確認
  - [ ] `!img sky | 16:9` → 通常生成（従来通り）
  - [ ] `!img sky | 1:1`、`!img sky | 9:16`、`!img sky | 4:3`、`!img sky | 3:4` → それぞれ成功
  - [ ] `!img sky` （aspect_ratio 省略）→ デフォルト `1:1` で生成、通知は出ない
  - [ ] `!img sky | 16;9` （タイポ）→ 「Unsupported aspect_ratio ...」メッセージ + `1:1` で生成継続
  - [ ] `!img sky | 5:7` （非サポート値）→ 同上
  - [ ] `!img sky | ` （末尾パイプのみ）→ デフォルトで生成、通知なし

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)