### PR TITLE
refactor: send !save file and preview in a single Discord message (#10)

### DIFF
--- a/GeminiDiscordBot.py
+++ b/GeminiDiscordBot.py
@@ -331,27 +331,22 @@ async def process_text_message(message, cleaned_text, save_to_file=False):
 
 
 async def save_response_as_file(message, response_text):
-    """
-    Saves the response as a markdown file and sends it to the Discord channel.
-    """
-    # Generate filename with timestamp
+    """Saves the response as a markdown file and sends it with an inline preview in a single message."""
     timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
     filename = f"gemini_response_{timestamp}.md"
 
-    # Create file object with response text
     file = discord.File(io.StringIO(response_text), filename=filename)
 
-    # Send message with attached file
-    await message.channel.send(f"💾 Here's your response as a file:", file=file)
-
-    # Preview of the first few lines (optional)
-    preview_lines = response_text.split("\n")[:5]  # First 5 lines
+    preview_lines = response_text.split("\n")[:5]
     preview = "\n".join(preview_lines)
     if len(preview_lines) >= 5:
         preview += "\n..."
 
-    if preview.strip():  # Send preview if content exists
-        await message.channel.send(f"📝 Preview:\n```\n{preview}\n```")
+    content = "💾 Here's your response as a file:"
+    if preview.strip():
+        content += f"\n📝 Preview:\n```\n{preview}\n```"
+
+    await message.channel.send(content, file=file)
 
 
 #################


### PR DESCRIPTION
## Summary
- `save_response_as_file` のファイル送信とプレビュー送信を `channel.send(content, file=file)` 1 回に統合
- 通知音・スクロール量が半減

## 挙動の保存
- プレビューの生成ロジック（先頭 5 行 + `...`）は据え置き
- プレビューが空のケース（`preview.strip()` が falsy）はヘッダーのみ送信 → 従来と同じく 1 メッセージ
- タイムスタンプ付きファイル名も据え置き

## 差分
`GeminiDiscordBot.py` のみ、+7 / -12 行。

## Test plan
- [x] `python -m py_compile GeminiDiscordBot.py` で構文検証済み
- [ ] 実機で以下を確認
  - [ ] `@Bot !save 長い応答を返してほしい内容...` → 1 メッセージにファイル + プレビューが添付される
  - [ ] 空または極短の応答が返るケース → ヘッダーのみの 1 メッセージ
  - [ ] ファイルが gemini_response_<timestamp>.md として添付されている
  - [ ] 通知音が 1 回のみ

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)