### PR TITLE
feat: add !dr Deep Research command with background execution (#22)

### DIFF
--- a/GeminiDiscordBot.py
+++ b/GeminiDiscordBot.py
@@ -65,7 +65,7 @@ DEFAULT_ASPECT_RATIO = "1:1"
 
 # Deep Research (Route B: direct Gemini API key, separate from the Vertex client)
 DEEP_RESEARCH_API_KEY = os.getenv("DEEP_RESEARCH_API_KEY")
-DEEP_RESEARCH_MODEL = os.getenv("DEEP_RESEARCH_MODEL", "deep-research-preview-04-2026")
+DEEP_RESEARCH_AGENT = os.getenv("DEEP_RESEARCH_AGENT", "deep-research-preview-04-2026")
 DEEP_RESEARCH_MAX_CONCURRENT = int(os.getenv("DEEP_RESEARCH_MAX_CONCURRENT", "2"))
 DEEP_RESEARCH_POLL_SECONDS = int(os.getenv("DEEP_RESEARCH_POLL_SECONDS", "20"))
 DEEP_RESEARCH_TIMEOUT_SECONDS = int(os.getenv("DEEP_RESEARCH_TIMEOUT_SECONDS", "3900"))
@@ -159,7 +159,7 @@ dr_client = genai.Client(api_key=DEEP_RESEARCH_API_KEY) if DEEP_RESEARCH_API_KEY
 if dr_client is None:
     print("Deep Research disabled: DEEP_RESEARCH_API_KEY not set.")
 else:
-    print(f"Deep Research enabled (model={DEEP_RESEARCH_MODEL}, max_concurrent={DEEP_RESEARCH_MAX_CONCURRENT}).")
+    print(f"Deep Research enabled (agent={DEEP_RESEARCH_AGENT}, max_concurrent={DEEP_RESEARCH_MAX_CONCURRENT}).")
 
 # Initialize Discord bot
 intents = discord.Intents.default()
@@ -1116,7 +1116,7 @@ async def _run_deep_research(message, topic: str, ack) -> None:
             try:
                 interaction = await asyncio.to_thread(
                     dr_client.interactions.create,
-                    model=DEEP_RESEARCH_MODEL,
+                    agent=DEEP_RESEARCH_AGENT,
                     input=topic,
                     background=True,
                     store=True,

--- a/GeminiDiscordBot.py
+++ b/GeminiDiscordBot.py
@@ -8,7 +8,9 @@ import asyncio
 import magic
 import discord
 import tempfile
+import time
 import urllib.parse
+from dataclasses import dataclass
 from discord.ext import commands
 from dotenv import load_dotenv
 from google import genai
@@ -23,6 +25,21 @@ image_chat = {}
 # Holds strong references to fire-and-forget background tasks so the GC
 # cannot cancel them mid-flight (see https://docs.python.org/3/library/asyncio-task.html#asyncio.create_task).
 _background_tasks: set[asyncio.Task] = set()
+
+
+@dataclass
+class DeepResearchJob:
+    user_id: int
+    topic: str
+    interaction_id: str
+    task: asyncio.Task
+    ack_channel_id: int
+    ack_message_id: int
+    started_at: float  # time.monotonic() at job start
+
+
+# Per-user running Deep Research jobs. Only one concurrent job per user.
+deep_research_jobs: dict[int, DeepResearchJob] = {}
 
 # Load environment variables
 load_dotenv()
@@ -45,6 +62,14 @@ MAX_DISCORD_LENGTH = 2000
 # Supported aspect ratios for Gemini image generation
 SUPPORTED_ASPECT_RATIOS = frozenset({"1:1", "16:9", "9:16", "4:3", "3:4"})
 DEFAULT_ASPECT_RATIO = "1:1"
+
+# Deep Research (Route B: direct Gemini API key, separate from the Vertex client)
+DEEP_RESEARCH_API_KEY = os.getenv("DEEP_RESEARCH_API_KEY")
+DEEP_RESEARCH_MODEL = os.getenv("DEEP_RESEARCH_MODEL", "deep-research-preview-04-2026")
+DEEP_RESEARCH_MAX_CONCURRENT = int(os.getenv("DEEP_RESEARCH_MAX_CONCURRENT", "2"))
+DEEP_RESEARCH_POLL_SECONDS = int(os.getenv("DEEP_RESEARCH_POLL_SECONDS", "20"))
+DEEP_RESEARCH_TIMEOUT_SECONDS = int(os.getenv("DEEP_RESEARCH_TIMEOUT_SECONDS", "3900"))
+_dr_global_semaphore = asyncio.Semaphore(DEEP_RESEARCH_MAX_CONCURRENT)
 
 # Load the environment variable for enabling/disabling commands
 IMG_COMMANDS_ENABLED = os.getenv("IMG_COMMANDS_ENABLED", "False").lower() == "true"
@@ -128,6 +153,14 @@ generate_content_config = types.GenerateContentConfig(
 # Initialize Vertex AI API
 chat_model = genai.Client(vertexai=True, project=GCP_PROJECT_ID, location=GCP_REGION)
 
+# Initialize a separate direct-API client for Deep Research, which is not
+# currently served over Vertex AI for the preview models.
+dr_client = genai.Client(api_key=DEEP_RESEARCH_API_KEY) if DEEP_RESEARCH_API_KEY else None
+if dr_client is None:
+    print("Deep Research disabled: DEEP_RESEARCH_API_KEY not set.")
+else:
+    print(f"Deep Research enabled (model={DEEP_RESEARCH_MODEL}, max_concurrent={DEEP_RESEARCH_MAX_CONCURRENT}).")
+
 # Initialize Discord bot
 intents = discord.Intents.default()
 intents.message_content = True
@@ -191,6 +224,7 @@ async def on_message(message):
         save_to_file = False
         img_command = False
         edit_command = False
+        dr_command = False
 
         # Detect !save command
         if cleaned_text.startswith("!save "):
@@ -216,6 +250,25 @@ async def on_message(message):
                 return
             edit_command = True
             prompt_text = cleaned_text.replace("!edit ", "", 1)
+
+        # Detect !dr command (Deep Research)
+        elif cleaned_text.startswith("!dr "):
+            if dr_client is None:
+                await message.channel.send(
+                    "Deep Research is disabled (DEEP_RESEARCH_API_KEY not set)."
+                )
+                return
+            if message.author.id in deep_research_jobs:
+                await message.channel.send(
+                    "You already have a Deep Research job running. Wait for it to finish or send `RESET` to cancel."
+                )
+                return
+            topic = cleaned_text[4:].strip()
+            if not topic:
+                await message.channel.send("Usage: `!dr <topic>`")
+                return
+            dr_command = True
+            prompt_text = topic
 
         async with message.channel.typing():
             # Process cloud storage link (if exists)
@@ -255,6 +308,15 @@ async def on_message(message):
                 # Process !edit command
                 await message.channel.send(f"Editing: {prompt_text}")
                 await handle_edit_generation(message, prompt_text)
+
+            elif dr_command:
+                await message.add_reaction("🔬")
+                ack = await message.channel.send(
+                    f"🔬 Deep Research started: **{prompt_text}**\nStatus: queued…"
+                )
+                task = asyncio.create_task(_run_deep_research(message, prompt_text, ack))
+                _background_tasks.add(task)
+                task.add_done_callback(_background_tasks.discard)
 
             elif message.attachments:
                 await process_attachments(message, cleaned_text, save_to_file)
@@ -320,6 +382,9 @@ async def process_text_message(message, cleaned_text, save_to_file=False):
     if re.search(r"^RESET$", cleaned_text, re.IGNORECASE):
         chat.pop(message.author.id, None)
         image_chat.pop(message.author.id, None)
+        job = deep_research_jobs.pop(message.author.id, None)
+        if job is not None:
+            job.task.cancel()
         await message.channel.send(f"🧹 History (Text & Image) Reset for user: {message.author.name}")
         return
 
@@ -977,6 +1042,223 @@ async def update_text_chat_with_image(message, image_data, prompt_text):
         
     except Exception as e:
         logging.error(f"Failed to update text chat context: {e}")
+
+
+def _build_dr_injection(topic: str, report_text: str) -> str:
+    """Build a compact summary (≤1500 chars) of a Deep Research report to feed back
+    into the user's regular chat session as a new turn. Uses regex-only extraction
+    from the first 2000 chars so it costs nothing extra and stays deterministic.
+    """
+    head = report_text[:2000]
+    bullets: list[str] = []
+    for line in head.splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+        m = re.match(r"^#{1,3}\s+(.+)$", stripped)
+        if m:
+            bullets.append(m.group(1).strip())
+        else:
+            m = re.match(r"^[-*]\s+(.+)$", stripped)
+            if m:
+                bullets.append(m.group(1).strip())
+        if len(bullets) >= 8:
+            break
+    bullets_text = "\n".join(f"- {b[:120]}" for b in bullets) or "- (no bullets extracted)"
+    injection = (
+        f"[Deep Research completed — topic: \"{topic}\"]\n"
+        f"Key findings:\n{bullets_text}\n"
+        f"The full report has been posted as a .md attachment in this channel.\n"
+        f"You may reference it when the user asks follow-up questions."
+    )
+    return injection[:1500]
+
+
+async def _inject_dr_summary(message, topic: str, report_text: str) -> None:
+    """Append the Deep Research summary as a new turn in the user's text chat session.
+    Mirrors update_text_chat_with_image so follow-ups like "summarize the research"
+    naturally work via the regular chat path.
+    """
+    global chat
+    user_id = message.author.id
+    chat_session = chat.get(user_id)
+    if not chat_session:
+        chat_session = chat_model.aio.chats.create(
+            model=MODEL_ID,
+            config=generate_content_config,
+        )
+        chat[user_id] = chat_session
+    try:
+        await chat_session.send_message(_build_dr_injection(topic, report_text))
+        logging.info("Injected Deep Research summary into chat session for user %s", user_id)
+    except Exception:
+        logging.exception("Failed to inject Deep Research summary for user %s", user_id)
+
+
+async def _run_deep_research(message, topic: str, ack) -> None:
+    """Fire-and-forget task that drives a Deep Research interaction to completion.
+
+    Responsibilities:
+    - Gate via _dr_global_semaphore (global concurrency cap).
+    - Register state in deep_research_jobs so RESET and the per-user lock can see it.
+    - Poll client.interactions.get every DEEP_RESEARCH_POLL_SECONDS, edit the ack
+      message every ~60s as a heartbeat.
+    - On completion, post the full report via save_response_as_file, post a one-line
+      channel summary, and inject a compact summary into the text chat session.
+    - Handle cancel/timeout/failure paths with ack edits and emoji reactions.
+    """
+    user_id = message.author.id
+    started = time.monotonic()
+    last_heartbeat = 0.0
+    interaction_id: str | None = None
+    try:
+        async with _dr_global_semaphore:
+            try:
+                interaction = await asyncio.to_thread(
+                    dr_client.interactions.create,
+                    model=DEEP_RESEARCH_MODEL,
+                    input=topic,
+                    background=True,
+                    store=True,
+                )
+            except Exception as e:
+                logging.exception("Deep Research create failed for user %s", user_id)
+                try:
+                    await ack.edit(content=f"❌ Failed to start Deep Research: {e}")
+                except Exception:
+                    logging.exception("Failed to edit ack on create failure")
+                await message.add_reaction("❌")
+                return
+
+            interaction_id = interaction.id
+            deep_research_jobs[user_id] = DeepResearchJob(
+                user_id=user_id,
+                topic=topic,
+                interaction_id=interaction_id,
+                task=asyncio.current_task(),
+                ack_channel_id=ack.channel.id,
+                ack_message_id=ack.id,
+                started_at=started,
+            )
+
+            await ack.edit(
+                content=(
+                    f"🔬 Deep Research running\n"
+                    f"Topic: **{topic}**\n"
+                    f"id: `{interaction_id}`\n"
+                    f"elapsed 0m, status={interaction.status}"
+                )
+            )
+            last_heartbeat = time.monotonic()
+
+            while True:
+                elapsed = time.monotonic() - started
+                if elapsed > DEEP_RESEARCH_TIMEOUT_SECONDS:
+                    await ack.edit(
+                        content=(
+                            f"⏱️ Deep Research timed out after {int(elapsed / 60)}m\n"
+                            f"Topic: **{topic}**\n"
+                            f"id: `{interaction_id}`"
+                        )
+                    )
+                    await message.add_reaction("❌")
+                    return
+
+                await asyncio.sleep(DEEP_RESEARCH_POLL_SECONDS)
+
+                try:
+                    interaction = await asyncio.to_thread(
+                        dr_client.interactions.get, interaction_id
+                    )
+                except Exception as e:
+                    logging.exception(
+                        "Deep Research poll failed for user %s (id=%s)", user_id, interaction_id
+                    )
+                    try:
+                        await ack.edit(content=f"❌ Deep Research poll failed: {e}")
+                    except Exception:
+                        logging.exception("Failed to edit ack on poll failure")
+                    await message.add_reaction("❌")
+                    return
+
+                if interaction.status in ("completed", "failed"):
+                    break
+
+                if time.monotonic() - last_heartbeat >= 60:
+                    elapsed_min = int((time.monotonic() - started) / 60)
+                    try:
+                        await ack.edit(
+                            content=(
+                                f"🔬 Deep Research running\n"
+                                f"Topic: **{topic}**\n"
+                                f"id: `{interaction_id}`\n"
+                                f"elapsed {elapsed_min}m, status={interaction.status}"
+                            )
+                        )
+                    except Exception:
+                        logging.exception("Failed to edit heartbeat for user %s", user_id)
+                    last_heartbeat = time.monotonic()
+
+            elapsed_min = int((time.monotonic() - started) / 60)
+
+            if interaction.status == "completed":
+                try:
+                    report_text = interaction.outputs[-1].text if interaction.outputs else ""
+                except Exception:
+                    report_text = ""
+                    logging.exception("Failed to extract report text for user %s", user_id)
+
+                if not report_text:
+                    await ack.edit(
+                        content=(
+                            f"⚠️ Deep Research completed but returned empty output\n"
+                            f"Topic: **{topic}**\n"
+                            f"id: `{interaction_id}`"
+                        )
+                    )
+                    await message.add_reaction("⚠️")
+                    return
+
+                await save_response_as_file(message, report_text)
+                await message.channel.send(
+                    f"✅ Deep Research completed ({elapsed_min}m) — topic: **{topic}**"
+                )
+                await _inject_dr_summary(message, topic, report_text)
+                await message.add_reaction("✅")
+                await ack.edit(
+                    content=(
+                        f"✅ Deep Research completed ({elapsed_min}m)\n"
+                        f"Topic: **{topic}**\n"
+                        f"id: `{interaction_id}`"
+                    )
+                )
+            else:  # failed
+                error_msg = getattr(interaction, "error", "<unknown>")
+                await message.channel.send(f"❌ Deep Research failed: {error_msg}")
+                await ack.edit(
+                    content=(
+                        f"❌ Deep Research failed ({elapsed_min}m)\n"
+                        f"Topic: **{topic}**\n"
+                        f"id: `{interaction_id}`\n"
+                        f"error: {error_msg}"
+                    )
+                )
+                await message.add_reaction("❌")
+
+    except asyncio.CancelledError:
+        try:
+            await ack.edit(content=f"🛑 Deep Research cancelled\nTopic: **{topic}**")
+        except Exception:
+            logging.exception("Failed to edit ack on cancel")
+        raise
+    except Exception:
+        logging.exception("Deep Research task failed unexpectedly for user %s", user_id)
+        try:
+            await ack.edit(content=f"❌ Deep Research encountered an unexpected error\nTopic: **{topic}**")
+        except Exception:
+            logging.exception("Failed to edit ack on unexpected error")
+    finally:
+        deep_research_jobs.pop(user_id, None)
 
 
 # Run the bot

--- a/GeminiDiscordBot.py
+++ b/GeminiDiscordBot.py
@@ -104,7 +104,18 @@ if not ALLOWED_USER_IDS:
 else:
     print(f"Allowed user IDs: {ALLOWED_USER_IDS}")
 
-# Configure logging for user interactions
+# Root logging configuration: make logging.info / logging.exception calls
+# visible on stderr. Without this, the default root logger level is WARNING
+# and our .info diagnostics (Deep Research output shape, grounding metadata,
+# etc.) would be silently dropped.
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    datefmt="%Y-%m-%d %H:%M:%S",
+)
+
+# Dedicated access log for user interactions. Does not propagate so it only
+# writes to bot_usage.log, not stderr.
 log_formatter = logging.Formatter(
     "%(asctime)s - %(message)s", datefmt="%Y-%m-%d %H:%M:%S"
 )

--- a/GeminiDiscordBot.py
+++ b/GeminiDiscordBot.py
@@ -1205,7 +1205,19 @@ async def _run_deep_research(message, topic: str, ack) -> None:
 
             if interaction.status == "completed":
                 try:
-                    report_text = interaction.outputs[-1].text if interaction.outputs else ""
+                    outputs = interaction.outputs or []
+                    # Deep Research returns multiple outputs (report body, sources,
+                    # thought summaries, visualizations). The last one is typically
+                    # the citations list, not the body, so concatenate every output
+                    # that exposes a text attribute.
+                    logging.info(
+                        "Deep Research completed for user %s: %d outputs, types=%s",
+                        user_id,
+                        len(outputs),
+                        [getattr(o, "type", "?") for o in outputs],
+                    )
+                    parts = [t for t in (getattr(o, "text", None) for o in outputs) if t]
+                    report_text = "\n\n".join(parts).strip()
                 except Exception:
                     report_text = ""
                     logging.exception("Failed to extract report text for user %s", user_id)

--- a/GeminiDiscordBot.py
+++ b/GeminiDiscordBot.py
@@ -251,8 +251,10 @@ async def on_message(message):
             edit_command = True
             prompt_text = cleaned_text.replace("!edit ", "", 1)
 
-        # Detect !dr command (Deep Research)
-        elif cleaned_text.startswith("!dr "):
+        # Detect !dr command (Deep Research). Match both "!dr" and "!dr ..."
+        # so a bare "!dr" shows usage instead of falling through to chat and
+        # wasting an API call.
+        elif cleaned_text == "!dr" or cleaned_text.startswith("!dr "):
             if dr_client is None:
                 await message.channel.send(
                     "Deep Research is disabled (DEEP_RESEARCH_API_KEY not set)."

--- a/README.md
+++ b/README.md
@@ -108,6 +108,17 @@ Gemini Discord Bot allows you to converse on Discord using Google's Gemini API. 
   - After generating or editing an image, it is automatically shared with the text chat.
   - You can immediately ask questions about the image in the normal chat (e.g., "Describe the architecture").
 
+- **Deep Research**: Use the `!dr` command to run Google's Gemini Deep Research agent in the background.
+  ```text
+  !dr <topic>
+  ```
+  - **Topic**: The research question. The agent performs multi-step web search and synthesis.
+  - **Latency**: Several minutes to tens of minutes per job (60-minute hard cap). Normal chat remains fully responsive while a research job runs.
+  - **Cost**: Approximately US$1–$7 per research depending on the model. Set `ALLOWED_USER_IDS` and keep `DEEP_RESEARCH_MAX_CONCURRENT` modest.
+  - **Output**: The full report is delivered as a Markdown attachment. A compact summary is automatically injected into the text chat session so you can ask follow-ups like "summarize the key findings" or "what sources did it cite?" without re-uploading anything.
+  - **Cancel**: Send `RESET` to cancel a running research job (this also clears the chat and image history).
+  - **Requires**: `DEEP_RESEARCH_API_KEY` environment variable (Google AI Studio key). The Vertex AI client used for normal chat does not currently serve the Deep Research preview models, so a separate direct API key is required.
+
 ---
 
 ## Security Considerations

--- a/env.sample
+++ b/env.sample
@@ -26,3 +26,17 @@ ALLOWED_USER_IDS = ""
 
 # Debug settings (Directory for saving cloud files)
 # DEBUG_FILES_DIR = "debug_files"
+
+# Deep Research (!dr command)
+## Direct Gemini API key. Leave empty to disable !dr.
+## (Deep Research preview models are not served via Vertex AI; a separate
+## direct API key is required even though the rest of the bot uses Vertex.)
+DEEP_RESEARCH_API_KEY = ""
+## Deep Research model ID. Default: deep-research-preview-04-2026
+# DEEP_RESEARCH_MODEL = "deep-research-preview-04-2026"
+## Max concurrent Deep Research jobs across all users. Default: 2
+# DEEP_RESEARCH_MAX_CONCURRENT = "2"
+## Poll interval in seconds. Default: 20
+# DEEP_RESEARCH_POLL_SECONDS = "20"
+## Timeout in seconds (should exceed the 60-minute API cap). Default: 3900
+# DEEP_RESEARCH_TIMEOUT_SECONDS = "3900"

--- a/env.sample
+++ b/env.sample
@@ -32,8 +32,11 @@ ALLOWED_USER_IDS = ""
 ## (Deep Research preview models are not served via Vertex AI; a separate
 ## direct API key is required even though the rest of the bot uses Vertex.)
 DEEP_RESEARCH_API_KEY = ""
-## Deep Research model ID. Default: deep-research-preview-04-2026
-# DEEP_RESEARCH_MODEL = "deep-research-preview-04-2026"
+## Deep Research agent ID. Default: deep-research-preview-04-2026
+## (Note: Deep Research is passed in the `agent` field of interactions.create,
+##  not `model`, per the Gemini API. Accepted values:
+##  deep-research-preview-04-2026 or deep-research-max-preview-04-2026.)
+# DEEP_RESEARCH_AGENT = "deep-research-preview-04-2026"
 ## Max concurrent Deep Research jobs across all users. Default: 2
 # DEEP_RESEARCH_MAX_CONCURRENT = "2"
 ## Poll interval in seconds. Default: 20


### PR DESCRIPTION
## Summary
- Gemini Deep Research エージェントを `!dr <topic>` コマンドとして追加
- 数分〜数十分の Research をバックグラウンド実行、**通常チャットは全くブロックしない**
- 完了時: `.md` ファイル添付 + 1 行サマリ + コンパクト要約をチャットセッションに自動注入（既存の `update_text_chat_with_image` と同発想）
- 307 行追加、3 ファイル変更

## クライアント戦略（Phase 0 spike 結果に基づく Route B）
Vertex AI 経由では `deep-research-preview-04-2026` モデルが `Unsupported model interaction` で 400 返却のため、**直 Gemini API キーを用いた 2 本目のクライアント `dr_client` を追加**。既存 Vertex AI クライアント (`chat_model`) は通常チャット・`!img` / `!edit` 用に据え置き。`DEEP_RESEARCH_API_KEY` 未設定時は `!dr` のみ無効化、他機能には影響しない。

## 主要な変更点
- `DeepResearchJob` dataclass + `deep_research_jobs` dict（per-user 1 件まで）
- `_dr_global_semaphore`（`DEEP_RESEARCH_MAX_CONCURRENT` で同時実行数制御、既定 2）
- `on_message` で `!dr` 検出 → ack 送信 + 🔬 → `_background_tasks` パターンでタスク起動
- `_run_deep_research`: `interactions.create` → 20 秒周期でポーリング → 約 60 秒ごとに ack を edit してハートビート表示
- 完了時: `save_response_as_file` で `.md` 送信、✅、`_inject_dr_summary` で chat_session に要約注入
- 失敗 / タイムアウト / CancelledError / 想定外例外の全パスで ack を最終状態に edit し、`deep_research_jobs` を cleanup
- `RESET` で `deep_research_jobs[user_id].task.cancel()`（既存 chat/image_chat クリアに加算）
- `asyncio.to_thread` で SDK の同期 API を非同期化

## 新規 env var
- `DEEP_RESEARCH_API_KEY` — Google AI Studio API キー（未設定 = 機能無効）
- `DEEP_RESEARCH_MODEL` — 既定 `deep-research-preview-04-2026`
- `DEEP_RESEARCH_MAX_CONCURRENT` — 既定 `2`
- `DEEP_RESEARCH_POLL_SECONDS` — 既定 `20`
- `DEEP_RESEARCH_TIMEOUT_SECONDS` — 既定 `3900`（65 分、API 側 60 分上限 + マージン）

## 既存パターンの再利用
- `_background_tasks` + 3 行イディオム（GC による中断防止）
- `save_response_as_file` — 60–80K tokens の巨大出力にも耐える（`split_and_send_messages` を使わない理由: Discord rate limit 抵触懸念）
- `update_text_chat_with_image` と同じ chat_session 注入パターン
- `ALLOWED_USER_IDS` 既存チェック

## Test plan
- [x] `python -m py_compile GeminiDiscordBot.py` で構文検証済み
- [ ] **happy path**: `DEEP_RESEARCH_API_KEY` を設定して `!dr 2026 年の室温超伝導の進捗` → ack が約 60 秒ごとに edit される、完了時に `.md` + ✅、直後「要点を 3 つにまとめて」で文脈が通る
- [ ] **非ブロッキング**: Research 実行中に `!img neko | 16:9` / 通常テキストチャット両方成功
- [ ] **per-user ロック**: 実行中に 2 件目 `!dr` → 拒否メッセージ、1 件目は継続
- [ ] **global ロック**: `DEEP_RESEARCH_MAX_CONCURRENT=1` で 2 ユーザー同時 → 2 件目は「queued…」のまま、1 件目完了後に走る
- [ ] **RESET 中断**: 実行中 `RESET` → ack が 🛑 cancelled に edit、`deep_research_jobs` が空
- [ ] **失敗**: 不正 API キーで ❌ + error 本文がチャンネルに出る
- [ ] **タイムアウト**: `DEEP_RESEARCH_TIMEOUT_SECONDS=60` に下げて短縮実行 → ⏱️ timeout 分岐
- [ ] **disabled**: `DEEP_RESEARCH_API_KEY` 未設定で `!dr foo` → 「disabled」メッセージのみ、API 呼び出しなし

## Non-Goals（別 Issue または将来対応）
- Bot 再起動で走行中 Research 状態が失われる問題（永続化なし）
- citations 構造の詳細整形（現状は本文テキストのみ抽出）
- per-user の頻度制限
- スラッシュコマンド化（`/dr` / `/reset` / 他）

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)