### PR TITLE
feat: !dr collaborative planning + visualization + multimodal input (#24)

### DIFF
--- a/GeminiDiscordBot.py
+++ b/GeminiDiscordBot.py
@@ -5,6 +5,7 @@ import aiohttp
 import io
 
 import asyncio
+import base64
 import magic
 import discord
 import tempfile
@@ -40,6 +41,22 @@ class DeepResearchJob:
 
 # Per-user running Deep Research jobs. Only one concurrent job per user.
 deep_research_jobs: dict[int, DeepResearchJob] = {}
+
+
+@dataclass
+class DeepResearchPlan:
+    user_id: int
+    topic: str
+    plan_interaction_id: str   # latest planning interaction id (chain target)
+    plan_text: str              # most recent plan text for display
+    channel_id: int             # where the plan was posted
+    created_at: float
+
+
+# Per-user pending plans awaiting an Approve / Refine / Abort decision.
+# Invariant: for any user_id, at most one of deep_research_jobs[user_id]
+# and deep_research_plans[user_id] is set at any time.
+deep_research_plans: dict[int, DeepResearchPlan] = {}
 
 # Load environment variables
 load_dotenv()
@@ -276,6 +293,11 @@ async def on_message(message):
                     "You already have a Deep Research job running. Wait for it to finish or send `RESET` to cancel."
                 )
                 return
+            if message.author.id in deep_research_plans:
+                await message.channel.send(
+                    "You already have a pending Deep Research plan. Approve, refine, or abort it first (or send `RESET`)."
+                )
+                return
             topic = cleaned_text[4:].strip()
             if not topic:
                 await message.channel.send("Usage: `!dr <topic>`")
@@ -324,12 +346,22 @@ async def on_message(message):
 
             elif dr_command:
                 await message.add_reaction("🔬")
-                ack = await message.channel.send(
-                    f"🔬 Deep Research started: **{prompt_text}**\nStatus: queued…"
+                attachments = (
+                    await download_attachments_as_parts(message)
+                    if message.attachments else []
                 )
-                task = asyncio.create_task(_run_deep_research(message, prompt_text, ack))
-                _background_tasks.add(task)
-                task.add_done_callback(_background_tasks.discard)
+                view = PlanOrDirectView(
+                    user_id=message.author.id,
+                    topic=prompt_text,
+                    origin_message=message,
+                    attachments=attachments,
+                )
+                ack = await message.channel.send(
+                    f"🔬 Deep Research requested: **{prompt_text}**\n"
+                    f"Choose a flow below.",
+                    view=view,
+                )
+                view.ack = ack
 
             elif message.attachments:
                 await process_attachments(message, cleaned_text, save_to_file)
@@ -398,6 +430,7 @@ async def process_text_message(message, cleaned_text, save_to_file=False):
         job = deep_research_jobs.pop(message.author.id, None)
         if job is not None:
             job.task.cancel()
+        deep_research_plans.pop(message.author.id, None)
         await message.channel.send(f"🧹 History (Text & Image) Reset for user: {message.author.name}")
         return
 
@@ -1108,39 +1141,336 @@ async def _inject_dr_summary(message, topic: str, report_text: str) -> None:
         logging.exception("Failed to inject Deep Research summary for user %s", user_id)
 
 
-async def _run_deep_research(message, topic: str, ack) -> None:
+class PlanOrDirectView(discord.ui.View):
+    """Initial UI shown after `!dr <topic>`. Picks plan-first vs direct-run."""
+
+    def __init__(
+        self,
+        *,
+        user_id: int,
+        topic: str,
+        origin_message: discord.Message,
+        attachments: list,
+        timeout: float = 300,
+    ):
+        super().__init__(timeout=timeout)
+        self.user_id = user_id
+        self.topic = topic
+        self.origin_message = origin_message
+        self.attachments = attachments
+        self.ack: discord.Message | None = None
+
+    async def interaction_check(self, interaction: discord.Interaction) -> bool:
+        if interaction.user.id != self.user_id:
+            await interaction.response.send_message(
+                "This Deep Research request isn't yours.", ephemeral=True
+            )
+            return False
+        return True
+
+    async def on_timeout(self) -> None:
+        for child in self.children:
+            child.disabled = True
+        if self.ack is not None:
+            try:
+                await self.ack.edit(
+                    content=f"⏱️ Deep Research request timed out (no selection)\nTopic: **{self.topic}**",
+                    view=self,
+                )
+            except Exception:
+                logging.exception("PlanOrDirectView on_timeout edit failed")
+
+    def _spawn(self, *, planning_mode: bool) -> None:
+        task = asyncio.create_task(
+            _run_deep_research(
+                self.origin_message,
+                self.topic,
+                self.ack,
+                planning_mode=planning_mode,
+                attachments=self.attachments,
+            )
+        )
+        _background_tasks.add(task)
+        task.add_done_callback(_background_tasks.discard)
+
+    @discord.ui.button(label="📋 Plan first", style=discord.ButtonStyle.primary)
+    async def plan_button(self, interaction: discord.Interaction, button: discord.ui.Button):
+        if self.user_id in deep_research_jobs:
+            await interaction.response.send_message(
+                "You already have a Deep Research job running.", ephemeral=True
+            )
+            return
+        self.stop()
+        for child in self.children:
+            child.disabled = True
+        await interaction.response.edit_message(
+            content=f"📋 Preparing plan for: **{self.topic}**…",
+            view=self,
+        )
+        self._spawn(planning_mode=True)
+
+    @discord.ui.button(label="🚀 Run now", style=discord.ButtonStyle.success)
+    async def direct_button(self, interaction: discord.Interaction, button: discord.ui.Button):
+        if self.user_id in deep_research_jobs:
+            await interaction.response.send_message(
+                "You already have a Deep Research job running.", ephemeral=True
+            )
+            return
+        self.stop()
+        for child in self.children:
+            child.disabled = True
+        await interaction.response.edit_message(
+            content=f"🔬 Deep Research starting: **{self.topic}**…",
+            view=self,
+        )
+        self._spawn(planning_mode=False)
+
+
+class PlanDecisionView(discord.ui.View):
+    """Plan review UI shown after a planning call completes."""
+
+    def __init__(
+        self,
+        *,
+        user_id: int,
+        topic: str,
+        plan_interaction_id: str,
+        origin_message: discord.Message,
+        timeout: float = 1800,
+    ):
+        super().__init__(timeout=timeout)
+        self.user_id = user_id
+        self.topic = topic
+        self.plan_interaction_id = plan_interaction_id
+        self.origin_message = origin_message
+        self.ack: discord.Message | None = None
+
+    async def interaction_check(self, interaction: discord.Interaction) -> bool:
+        if interaction.user.id != self.user_id:
+            await interaction.response.send_message(
+                "This plan isn't yours.", ephemeral=True
+            )
+            return False
+        return True
+
+    def _plan_is_fresh(self) -> bool:
+        current = deep_research_plans.get(self.user_id)
+        return current is not None and current.plan_interaction_id == self.plan_interaction_id
+
+    async def on_timeout(self) -> None:
+        for child in self.children:
+            child.disabled = True
+        if self.ack is not None:
+            try:
+                await self.ack.edit(content="⏱️ Plan decision timed out.", view=self)
+            except Exception:
+                logging.exception("PlanDecisionView on_timeout edit failed")
+
+    @discord.ui.button(label="✅ Approve & execute", style=discord.ButtonStyle.success)
+    async def approve_button(self, interaction: discord.Interaction, button: discord.ui.Button):
+        if not self._plan_is_fresh():
+            await interaction.response.send_message(
+                "This plan has been reset. Please start a new `!dr` request.", ephemeral=True
+            )
+            return
+        if self.user_id in deep_research_jobs:
+            await interaction.response.send_message(
+                "You already have a Deep Research job running.", ephemeral=True
+            )
+            return
+        deep_research_plans.pop(self.user_id, None)
+        self.stop()
+        for child in self.children:
+            child.disabled = True
+        await interaction.response.edit_message(
+            content=f"✅ Approved — executing research on **{self.topic}**",
+            view=self,
+        )
+        exec_ack = await interaction.channel.send(
+            f"🔬 Deep Research starting (execute): **{self.topic}**\nStatus: queued…"
+        )
+        task = asyncio.create_task(
+            _run_deep_research(
+                self.origin_message,
+                self.topic,
+                exec_ack,
+                planning_mode=False,
+                previous_interaction_id=self.plan_interaction_id,
+                input_override="Execute the plan.",
+            )
+        )
+        _background_tasks.add(task)
+        task.add_done_callback(_background_tasks.discard)
+
+    @discord.ui.button(label="✏️ Refine", style=discord.ButtonStyle.primary)
+    async def refine_button(self, interaction: discord.Interaction, button: discord.ui.Button):
+        if not self._plan_is_fresh():
+            await interaction.response.send_message(
+                "This plan has been reset. Please start a new `!dr` request.", ephemeral=True
+            )
+            return
+        if self.user_id in deep_research_jobs:
+            await interaction.response.send_message(
+                "You already have a Deep Research job running.", ephemeral=True
+            )
+            return
+        await interaction.response.send_modal(
+            RefineModal(
+                user_id=self.user_id,
+                topic=self.topic,
+                plan_interaction_id=self.plan_interaction_id,
+                origin_message=self.origin_message,
+                view=self,
+            )
+        )
+
+    @discord.ui.button(label="🛑 Abort", style=discord.ButtonStyle.danger)
+    async def abort_button(self, interaction: discord.Interaction, button: discord.ui.Button):
+        deep_research_plans.pop(self.user_id, None)
+        self.stop()
+        for child in self.children:
+            child.disabled = True
+        await interaction.response.edit_message(
+            content=f"🛑 Plan aborted: **{self.topic}**",
+            view=self,
+        )
+
+
+class RefineModal(discord.ui.Modal, title="Refine Deep Research Plan"):
+    refinement = discord.ui.TextInput(
+        label="Refinement instructions",
+        style=discord.TextStyle.paragraph,
+        placeholder="e.g., Include more on cost and power consumption.",
+        max_length=2000,
+        required=True,
+    )
+
+    def __init__(
+        self,
+        *,
+        user_id: int,
+        topic: str,
+        plan_interaction_id: str,
+        origin_message: discord.Message,
+        view: "PlanDecisionView",
+    ):
+        super().__init__()
+        self.user_id = user_id
+        self.topic = topic
+        self.plan_interaction_id = plan_interaction_id
+        self.origin_message = origin_message
+        self.parent_view = view
+
+    async def on_submit(self, interaction: discord.Interaction):
+        text = self.refinement.value.strip()
+        if not text:
+            await interaction.response.send_message("Empty refinement ignored.", ephemeral=True)
+            return
+        if self.user_id in deep_research_jobs:
+            await interaction.response.send_message(
+                "You already have a Deep Research job running.", ephemeral=True
+            )
+            return
+        current = deep_research_plans.get(self.user_id)
+        if current is None or current.plan_interaction_id != self.plan_interaction_id:
+            await interaction.response.send_message(
+                "This plan has been reset. Please start a new `!dr` request.", ephemeral=True
+            )
+            return
+
+        await interaction.response.send_message("✏️ Refining plan…", ephemeral=True)
+
+        # Clear the prior plan; a new one will replace it when refinement completes.
+        deep_research_plans.pop(self.user_id, None)
+        self.parent_view.stop()
+        for child in self.parent_view.children:
+            child.disabled = True
+        if self.parent_view.ack is not None:
+            try:
+                await self.parent_view.ack.edit(view=self.parent_view)
+            except Exception:
+                logging.exception("Failed to disable old PlanDecisionView on refine")
+
+        refine_ack = await interaction.channel.send(
+            f"📋 Refining plan with: {text[:200]}\nTopic: **{self.topic}**"
+        )
+        task = asyncio.create_task(
+            _run_deep_research(
+                self.origin_message,
+                self.topic,
+                refine_ack,
+                planning_mode=True,
+                previous_interaction_id=self.plan_interaction_id,
+                input_override=text,
+            )
+        )
+        _background_tasks.add(task)
+        task.add_done_callback(_background_tasks.discard)
+
+
+async def _run_deep_research(
+    message,
+    topic: str,
+    ack,
+    *,
+    planning_mode: bool = False,
+    previous_interaction_id: str | None = None,
+    input_override: str | None = None,
+    attachments: list | None = None,
+) -> None:
     """Fire-and-forget task that drives a Deep Research interaction to completion.
 
-    Responsibilities:
-    - Gate via _dr_global_semaphore (global concurrency cap).
-    - Register state in deep_research_jobs so RESET and the per-user lock can see it.
-    - Poll client.interactions.get every DEEP_RESEARCH_POLL_SECONDS, edit the ack
-      message every ~60s as a heartbeat.
-    - On completion, post the full report via save_response_as_file, post a one-line
-      channel summary, and inject a compact summary into the text chat session.
-    - Handle cancel/timeout/failure paths with ack edits and emoji reactions.
+    Modes:
+    - planning_mode=True: run a collaborative-planning call. On completion,
+      store the plan in deep_research_plans and attach a PlanDecisionView.
+    - planning_mode=False (default): run execution. May chain from a previous
+      plan via previous_interaction_id. On completion, post the .md report,
+      inject a compact summary into the text chat session, and post any
+      generated visualization images.
     """
     user_id = message.author.id
     started = time.monotonic()
     last_heartbeat = 0.0
     interaction_id: str | None = None
+    ack_prefix = "📋 Planning" if planning_mode else "🔬 Deep Research"
     try:
         async with _dr_global_semaphore:
+            agent_config: dict = {"visualization": "auto"}
+            if planning_mode:
+                agent_config["collaborative_planning"] = True
+
+            if previous_interaction_id is None:
+                effective_input = (
+                    [topic, *attachments] if attachments else topic
+                )
+            else:
+                effective_input = input_override or "Execute the plan."
+
+            create_kwargs = dict(
+                agent=DEEP_RESEARCH_AGENT,
+                input=effective_input,
+                agent_config=agent_config,
+                background=True,
+                store=True,
+            )
+            if previous_interaction_id is not None:
+                create_kwargs["previous_interaction_id"] = previous_interaction_id
+
             try:
                 interaction = await asyncio.to_thread(
-                    dr_client.interactions.create,
-                    agent=DEEP_RESEARCH_AGENT,
-                    input=topic,
-                    background=True,
-                    store=True,
+                    dr_client.interactions.create, **create_kwargs
                 )
             except Exception as e:
-                logging.exception("Deep Research create failed for user %s", user_id)
+                logging.exception(
+                    "Deep Research create failed for user %s (planning_mode=%s)",
+                    user_id, planning_mode,
+                )
                 try:
-                    await ack.edit(content=f"❌ Failed to start Deep Research: {e}")
+                    await ack.edit(content=f"❌ Failed to start Deep Research: {e}", view=None)
                 except Exception:
                     logging.exception("Failed to edit ack on create failure")
-                await message.add_reaction("❌")
+                if not planning_mode:
+                    await message.add_reaction("❌")
                 return
 
             interaction_id = interaction.id
@@ -1156,11 +1486,12 @@ async def _run_deep_research(message, topic: str, ack) -> None:
 
             await ack.edit(
                 content=(
-                    f"🔬 Deep Research running\n"
+                    f"{ack_prefix} running\n"
                     f"Topic: **{topic}**\n"
                     f"id: `{interaction_id}`\n"
                     f"elapsed 0m, status={interaction.status}"
-                )
+                ),
+                view=None,
             )
             last_heartbeat = time.monotonic()
 
@@ -1169,12 +1500,14 @@ async def _run_deep_research(message, topic: str, ack) -> None:
                 if elapsed > DEEP_RESEARCH_TIMEOUT_SECONDS:
                     await ack.edit(
                         content=(
-                            f"⏱️ Deep Research timed out after {int(elapsed / 60)}m\n"
+                            f"⏱️ {ack_prefix} timed out after {int(elapsed / 60)}m\n"
                             f"Topic: **{topic}**\n"
                             f"id: `{interaction_id}`"
-                        )
+                        ),
+                        view=None,
                     )
-                    await message.add_reaction("❌")
+                    if not planning_mode:
+                        await message.add_reaction("❌")
                     return
 
                 await asyncio.sleep(DEEP_RESEARCH_POLL_SECONDS)
@@ -1185,13 +1518,17 @@ async def _run_deep_research(message, topic: str, ack) -> None:
                     )
                 except Exception as e:
                     logging.exception(
-                        "Deep Research poll failed for user %s (id=%s)", user_id, interaction_id
+                        "Deep Research poll failed for user %s (id=%s)",
+                        user_id, interaction_id,
                     )
                     try:
-                        await ack.edit(content=f"❌ Deep Research poll failed: {e}")
+                        await ack.edit(
+                            content=f"❌ Deep Research poll failed: {e}", view=None
+                        )
                     except Exception:
                         logging.exception("Failed to edit ack on poll failure")
-                    await message.add_reaction("❌")
+                    if not planning_mode:
+                        await message.add_reaction("❌")
                     return
 
                 if interaction.status in ("completed", "failed"):
@@ -1202,11 +1539,12 @@ async def _run_deep_research(message, topic: str, ack) -> None:
                     try:
                         await ack.edit(
                             content=(
-                                f"🔬 Deep Research running\n"
+                                f"{ack_prefix} running\n"
                                 f"Topic: **{topic}**\n"
                                 f"id: `{interaction_id}`\n"
                                 f"elapsed {elapsed_min}m, status={interaction.status}"
-                            )
+                            ),
+                            view=None,
                         )
                     except Exception:
                         logging.exception("Failed to edit heartbeat for user %s", user_id)
@@ -1217,69 +1555,147 @@ async def _run_deep_research(message, topic: str, ack) -> None:
             if interaction.status == "completed":
                 try:
                     outputs = interaction.outputs or []
-                    # Deep Research returns multiple outputs (report body, sources,
-                    # thought summaries, visualizations). The last one is typically
-                    # the citations list, not the body, so concatenate every output
-                    # that exposes a text attribute.
                     logging.info(
-                        "Deep Research completed for user %s: %d outputs, types=%s",
-                        user_id,
-                        len(outputs),
+                        "Deep Research completed for user %s (planning_mode=%s): %d outputs, types=%s",
+                        user_id, planning_mode, len(outputs),
                         [getattr(o, "type", "?") for o in outputs],
                     )
-                    parts = [t for t in (getattr(o, "text", None) for o in outputs) if t]
-                    report_text = "\n\n".join(parts).strip()
+                    text_parts: list[str] = []
+                    image_files: list[discord.File] = []
+                    for i, out in enumerate(outputs):
+                        typ = getattr(out, "type", None)
+                        if typ == "image":
+                            raw = getattr(out, "data", None)
+                            if raw:
+                                try:
+                                    img_bytes = (
+                                        base64.b64decode(raw)
+                                        if isinstance(raw, str) else bytes(raw)
+                                    )
+                                    image_files.append(
+                                        discord.File(
+                                            io.BytesIO(img_bytes),
+                                            filename=f"dr_viz_{i}.png",
+                                        )
+                                    )
+                                except Exception:
+                                    logging.exception(
+                                        "Failed to decode Deep Research image %d", i
+                                    )
+                        else:
+                            txt = getattr(out, "text", None)
+                            if txt:
+                                text_parts.append(txt)
+                    result_text = "\n\n".join(text_parts).strip()
                 except Exception:
-                    report_text = ""
-                    logging.exception("Failed to extract report text for user %s", user_id)
+                    result_text = ""
+                    image_files = []
+                    logging.exception("Failed to extract result for user %s", user_id)
 
-                if not report_text:
+                if not result_text:
                     await ack.edit(
                         content=(
-                            f"⚠️ Deep Research completed but returned empty output\n"
+                            f"⚠️ {ack_prefix} completed but returned empty output\n"
                             f"Topic: **{topic}**\n"
                             f"id: `{interaction_id}`"
-                        )
+                        ),
+                        view=None,
                     )
-                    await message.add_reaction("⚠️")
+                    if not planning_mode:
+                        await message.add_reaction("⚠️")
                     return
 
-                await save_response_as_file(message, report_text)
-                await message.channel.send(
-                    f"✅ Deep Research completed ({elapsed_min}m) — topic: **{topic}**"
-                )
-                await _inject_dr_summary(message, topic, report_text)
-                await message.add_reaction("✅")
-                await ack.edit(
-                    content=(
-                        f"✅ Deep Research completed ({elapsed_min}m)\n"
-                        f"Topic: **{topic}**\n"
-                        f"id: `{interaction_id}`"
+                if planning_mode:
+                    deep_research_plans[user_id] = DeepResearchPlan(
+                        user_id=user_id,
+                        topic=topic,
+                        plan_interaction_id=interaction_id,
+                        plan_text=result_text,
+                        channel_id=ack.channel.id,
+                        created_at=started,
                     )
-                )
+                    header = f"📋 Deep Research plan ({elapsed_min}m) — topic: **{topic}**"
+                    combined = f"{header}\n\n{result_text}"
+                    if len(combined) <= MAX_DISCORD_LENGTH:
+                        await message.channel.send(combined)
+                    else:
+                        await message.channel.send(header)
+                        await split_and_send_messages(
+                            message, result_text, MAX_DISCORD_LENGTH
+                        )
+                    decision_view = PlanDecisionView(
+                        user_id=user_id,
+                        topic=topic,
+                        plan_interaction_id=interaction_id,
+                        origin_message=message,
+                    )
+                    decision_ack = await message.channel.send(
+                        "Approve, refine, or abort this plan:",
+                        view=decision_view,
+                    )
+                    decision_view.ack = decision_ack
+                    await ack.edit(
+                        content=(
+                            f"📋 Plan ready ({elapsed_min}m)\n"
+                            f"Topic: **{topic}**\n"
+                            f"id: `{interaction_id}`"
+                        ),
+                        view=None,
+                    )
+                    # No ✅ reaction yet — only the final execute gets it.
+                else:
+                    await save_response_as_file(message, result_text)
+                    await message.channel.send(
+                        f"✅ Deep Research completed ({elapsed_min}m) — topic: **{topic}**"
+                    )
+                    await _inject_dr_summary(message, topic, result_text)
+                    for chunk_start in range(0, len(image_files), 10):
+                        chunk = image_files[chunk_start:chunk_start + 10]
+                        header = (
+                            "🖼️ Visualizations"
+                            if len(image_files) <= 10
+                            else f"🖼️ Visualizations ({chunk_start + 1}-{chunk_start + len(chunk)} of {len(image_files)})"
+                        )
+                        await message.channel.send(content=header, files=chunk)
+                    await message.add_reaction("✅")
+                    await ack.edit(
+                        content=(
+                            f"✅ Deep Research completed ({elapsed_min}m)\n"
+                            f"Topic: **{topic}**\n"
+                            f"id: `{interaction_id}`"
+                        ),
+                        view=None,
+                    )
             else:  # failed
                 error_msg = getattr(interaction, "error", "<unknown>")
-                await message.channel.send(f"❌ Deep Research failed: {error_msg}")
+                await message.channel.send(f"❌ {ack_prefix} failed: {error_msg}")
                 await ack.edit(
                     content=(
-                        f"❌ Deep Research failed ({elapsed_min}m)\n"
+                        f"❌ {ack_prefix} failed ({elapsed_min}m)\n"
                         f"Topic: **{topic}**\n"
                         f"id: `{interaction_id}`\n"
                         f"error: {error_msg}"
-                    )
+                    ),
+                    view=None,
                 )
-                await message.add_reaction("❌")
+                if not planning_mode:
+                    await message.add_reaction("❌")
 
     except asyncio.CancelledError:
         try:
-            await ack.edit(content=f"🛑 Deep Research cancelled\nTopic: **{topic}**")
+            await ack.edit(
+                content=f"🛑 {ack_prefix} cancelled\nTopic: **{topic}**", view=None
+            )
         except Exception:
             logging.exception("Failed to edit ack on cancel")
         raise
     except Exception:
         logging.exception("Deep Research task failed unexpectedly for user %s", user_id)
         try:
-            await ack.edit(content=f"❌ Deep Research encountered an unexpected error\nTopic: **{topic}**")
+            await ack.edit(
+                content=f"❌ {ack_prefix} encountered an unexpected error\nTopic: **{topic}**",
+                view=None,
+            )
         except Exception:
             logging.exception("Failed to edit ack on unexpected error")
     finally:

--- a/GeminiDiscordBot.py
+++ b/GeminiDiscordBot.py
@@ -1139,6 +1139,30 @@ async def _inject_dr_summary(message, topic: str, report_text: str) -> None:
         logging.exception("Failed to inject Deep Research summary for user %s", user_id)
 
 
+def _build_dr_input(text: str, attachments: list | None):
+    """Build the `input` argument for `dr_client.interactions.create`.
+
+    Returns a plain string when there are no attachments, otherwise the
+    list-of-typed-content-dicts shape the Interactions API expects:
+        [{"type": "text", "text": "..."},
+         {"type": "image", "uri": "..."},
+         {"type": "document", "uri": "...", "mime_type": "..."}]
+    """
+    if not attachments:
+        return text
+    content_items: list[dict] = [{"type": "text", "text": text}]
+    for att in attachments:
+        content_type = (getattr(att, "content_type", None) or "").lower()
+        if content_type.startswith("image/"):
+            content_items.append({"type": "image", "uri": att.url})
+        else:
+            item = {"type": "document", "uri": att.url}
+            if content_type:
+                item["mime_type"] = content_type
+            content_items.append(item)
+    return content_items
+
+
 class PlanOrDirectView(discord.ui.View):
     """Initial UI shown after `!dr <topic>`. Picks plan-first vs direct-run."""
 
@@ -1287,6 +1311,10 @@ class PlanDecisionView(discord.ui.View):
         exec_ack = await interaction.channel.send(
             f"🔬 Deep Research starting (execute): **{self.topic}**\nStatus: queued…"
         )
+        origin_attachments = (
+            list(self.origin_message.attachments)
+            if self.origin_message.attachments else []
+        )
         task = asyncio.create_task(
             _run_deep_research(
                 self.origin_message,
@@ -1295,6 +1323,7 @@ class PlanDecisionView(discord.ui.View):
                 planning_mode=False,
                 previous_interaction_id=self.plan_interaction_id,
                 input_override="Execute the plan.",
+                attachments=origin_attachments,
             )
         )
         _background_tasks.add(task)
@@ -1392,6 +1421,10 @@ class RefineModal(discord.ui.Modal, title="Refine Deep Research Plan"):
         refine_ack = await interaction.channel.send(
             f"📋 Refining plan with: {text[:200]}\nTopic: **{self.topic}**"
         )
+        origin_attachments = (
+            list(self.origin_message.attachments)
+            if self.origin_message.attachments else []
+        )
         task = asyncio.create_task(
             _run_deep_research(
                 self.origin_message,
@@ -1400,6 +1433,7 @@ class RefineModal(discord.ui.Modal, title="Refine Deep Research Plan"):
                 planning_mode=True,
                 previous_interaction_id=self.plan_interaction_id,
                 input_override=text,
+                attachments=origin_attachments,
             )
         )
         _background_tasks.add(task)
@@ -1441,26 +1475,15 @@ async def _run_deep_research(
                 agent_config["collaborative_planning"] = True
 
             if previous_interaction_id is None:
-                if attachments:
-                    # Interactions API expects a list of typed content dicts with
-                    # URI references (not google-genai Part objects). Discord
-                    # attachment URLs are signed but accessible, which is enough
-                    # for the agent to fetch within the job lifetime.
-                    content_items: list[dict] = [{"type": "text", "text": topic}]
-                    for att in attachments:
-                        content_type = (getattr(att, "content_type", None) or "").lower()
-                        if content_type.startswith("image/"):
-                            content_items.append({"type": "image", "uri": att.url})
-                        else:
-                            item = {"type": "document", "uri": att.url}
-                            if content_type:
-                                item["mime_type"] = content_type
-                            content_items.append(item)
-                    effective_input = content_items
-                else:
-                    effective_input = topic
+                effective_input = _build_dr_input(topic, attachments)
             else:
-                effective_input = input_override or "Execute the plan."
+                # Refine / approve. Include the original attachments again so
+                # the shape (list of typed content dicts) matches the initial
+                # call; passing plain text here broke the previous_interaction_id
+                # context chain for multimodal plans — the server treated the
+                # refinement as a brand-new task rather than an addition.
+                text_for_chain = input_override or "Execute the plan."
+                effective_input = _build_dr_input(text_for_chain, attachments)
 
             create_kwargs = dict(
                 agent=DEEP_RESEARCH_AGENT,

--- a/GeminiDiscordBot.py
+++ b/GeminiDiscordBot.py
@@ -1435,7 +1435,10 @@ async def _run_deep_research(
     ack_prefix = "📋 Planning" if planning_mode else "🔬 Deep Research"
     try:
         async with _dr_global_semaphore:
-            agent_config: dict = {"visualization": "auto"}
+            # The Interactions API requires a discriminator "type" field inside
+            # agent_config. Without it the server returns 400:
+            #   "Missing key 'type' in input 'agent_config'."
+            agent_config: dict = {"type": "deep-research", "visualization": "auto"}
             if planning_mode:
                 agent_config["collaborative_planning"] = True
 

--- a/GeminiDiscordBot.py
+++ b/GeminiDiscordBot.py
@@ -346,15 +346,13 @@ async def on_message(message):
 
             elif dr_command:
                 await message.add_reaction("🔬")
-                attachments = (
-                    await download_attachments_as_parts(message)
-                    if message.attachments else []
-                )
+                # Keep attachments as discord.Attachment refs; the Interactions
+                # API fetches them by URI, so we do not need to download bytes.
                 view = PlanOrDirectView(
                     user_id=message.author.id,
                     topic=prompt_text,
                     origin_message=message,
-                    attachments=attachments,
+                    attachments=list(message.attachments),
                 )
                 ack = await message.channel.send(
                     f"🔬 Deep Research requested: **{prompt_text}**\n"
@@ -1443,9 +1441,24 @@ async def _run_deep_research(
                 agent_config["collaborative_planning"] = True
 
             if previous_interaction_id is None:
-                effective_input = (
-                    [topic, *attachments] if attachments else topic
-                )
+                if attachments:
+                    # Interactions API expects a list of typed content dicts with
+                    # URI references (not google-genai Part objects). Discord
+                    # attachment URLs are signed but accessible, which is enough
+                    # for the agent to fetch within the job lifetime.
+                    content_items: list[dict] = [{"type": "text", "text": topic}]
+                    for att in attachments:
+                        content_type = (getattr(att, "content_type", None) or "").lower()
+                        if content_type.startswith("image/"):
+                            content_items.append({"type": "image", "uri": att.url})
+                        else:
+                            item = {"type": "document", "uri": att.url}
+                            if content_type:
+                                item["mime_type"] = content_type
+                            content_items.append(item)
+                    effective_input = content_items
+                else:
+                    effective_input = topic
             else:
                 effective_input = input_override or "Execute the plan."
 

--- a/README.md
+++ b/README.md
@@ -112,11 +112,16 @@ Gemini Discord Bot allows you to converse on Discord using Google's Gemini API. 
   ```text
   !dr <topic>
   ```
+  After you send `!dr <topic>`, the bot posts two buttons:
+    - **📋 Plan first** — the agent returns a short research plan. You can then click **✅ Approve & execute**, **✏️ Refine** (opens a modal for refinement instructions), or **🛑 Abort**. Refining generates a new plan that you can iterate on again.
+    - **🚀 Run now** — skip planning and execute the research immediately (previous behavior).
   - **Topic**: The research question. The agent performs multi-step web search and synthesis.
+  - **Attachments (multimodal input)**: Attach an image or PDF to your `!dr` message to give the agent visual context. The attachments are only sent on the first call of a flow — for a plan → approve chain, they are attached to the planning call.
+  - **Visualizations**: The agent may embed PNG charts automatically when the topic asks for them (e.g., "include a chart comparing market share"). Generated images are posted alongside the report file. No configuration needed.
   - **Latency**: Several minutes to tens of minutes per job (60-minute hard cap). Normal chat remains fully responsive while a research job runs.
   - **Cost**: Approximately US$1–$7 per research depending on the model. Set `ALLOWED_USER_IDS` and keep `DEEP_RESEARCH_MAX_CONCURRENT` modest.
   - **Output**: The full report is delivered as a Markdown attachment. A compact summary is automatically injected into the text chat session so you can ask follow-ups like "summarize the key findings" or "what sources did it cite?" without re-uploading anything.
-  - **Cancel**: Send `RESET` to cancel a running research job (this also clears the chat and image history).
+  - **Cancel**: Send `RESET` to cancel a running job and clear any pending plan (also clears the chat and image history).
   - **Requires**: `DEEP_RESEARCH_API_KEY` environment variable (Google AI Studio key). The Vertex AI client used for normal chat does not currently serve the Deep Research preview models, so a separate direct API key is required.
 
 ---


### PR DESCRIPTION
## Summary
PR #23 で入った `!dr` ベースラインに、Deep Research docs の preview 発展機能 3 つを追加:

1. **Collaborative planning** — ボタン UI でプラン提案 → 修正 → 承認の 3 段フロー
2. **Visualization** — `agent_config={"visualization": "auto"}` 常時有効、画像出力を `discord.File` で同梱投稿
3. **マルチモーダル入力** — `!dr` メッセージの添付（画像 / PDF）を初回 `interactions.create` の `input` に含める

差分: GeminiDiscordBot.py +486 / -65、README.md の `!dr` セクション更新。

## 動作フロー

```
!dr <topic> [+ attachment]
  ↓
[PlanOrDirectView] 📋 Plan first  /  🚀 Run now
  ↓ (📋)                                ↓ (🚀)
Planning run (heartbeat)            Execute run (既存通り)
  ↓                                     ↓
[PlanDecisionView]                  .md + ✅ + 要約注入 + 画像
✅ Approve / ✏️ Refine / 🛑 Abort    (完了)
  ↓        ↓            ↓
Execute  [RefineModal] state clear
run      → 新 plan へ戻る
```

## 実装の要点

### State
- 新 `DeepResearchPlan` dataclass + `deep_research_plans: dict[int, DeepResearchPlan]`
- 不変条件: 同一ユーザーで `deep_research_jobs[uid]` と `deep_research_plans[uid]` のうち高々 1 つ set

### UI コンポーネント（`discord.ui`）
- **`PlanOrDirectView`** (timeout 300s) — `!dr` 直後。📋 / 🚀 の 2 ボタン
- **`PlanDecisionView`** (timeout 1800s) — プラン完成後。✅ / ✏️ / 🛑 の 3 ボタン
- **`RefineModal`** — paragraph TextInput 1 つ、max 2000 chars。submit で refine interaction を起動

全 View で `interaction_check` により非所有者クリックを ephemeral で拒否。コールバック内で plan 鮮度を `plan_interaction_id` 照合で確認し、stale なら ephemeral で「リセット済み」通知。

### `_run_deep_research` 拡張
```python
async def _run_deep_research(
    message, topic, ack, *,
    planning_mode=False,
    previous_interaction_id=None,
    input_override=None,
    attachments=None,
) -> None
```
- `agent_config` は常に `{"visualization": "auto"}`、planning 時 `"collaborative_planning": True` 追加
- `input` 決定:
  - 初回 (previous_interaction_id=None): `[topic, *attachments]` or `topic`
  - 継続 (refine/approve): `input_override` or `"Execute the plan."`
- 完了分岐が planning / execute で別れる
- 出力走査で `type == "image"` を base64 デコード → `discord.File`

### RESET 連携
既存の `deep_research_jobs` cancel に加えて `deep_research_plans.pop(uid, None)` を追加。

## 既存実装の再利用
- `_background_tasks` + 3 行イディオム（GC protection）
- `save_response_as_file` — `.md` 送信
- `_inject_dr_summary` / `_build_dr_injection` — execute 完了時の chat 注入
- `split_and_send_messages` — プランが 2000 字超のフォールバック
- `download_attachments_as_parts` — 添付を `types.Part` 化

## Test plan
- [x] `python -m py_compile GeminiDiscordBot.py` で構文検証済み
- [ ] **直接実行（後方互換）**: `!dr <topic>` → 🚀 → `.md` 正常到達
- [ ] **プラン・承認**: `!dr <topic>` → 📋 → プラン → ✅ → execute 完走、要約注入
- [ ] **プラン・修正・承認**: 📋 → プラン → ✏️ → Modal 入力 → submit → 修正版プラン → ✅ → execute
- [ ] **Abort**: 📋 → プラン → 🛑 → state クリア、新しい `!dr` 即通る
- [ ] **Visualization**: `!dr 比較グラフを含めて 2026 年の TPU 進化` → `.md` + `dr_viz_N.png` 投稿
- [ ] **マルチモーダル (直接)**: PDF 添付 + `!dr この文書の根拠を調べて` → 🚀 → 内容を踏まえた `.md`
- [ ] **マルチモーダル (プラン)**: 画像添付 + `!dr plan the topic in this image` → 📋 → プランに画像内容が反映 → ✅
- [ ] **Timeout (PlanOrDirectView 5m)**: 放置 → ボタン disabled
- [ ] **他ユーザー誤クリック**: ephemeral で拒否、state 不変
- [ ] **RESET 中断（プラン保持中）**: RESET → `deep_research_plans` 空、stale ボタンで ephemeral エラー
- [ ] **RESET 中断（実行中）**: 既存の `job.task.cancel` が従来通り動く

## Non-Goals（別 Issue で後続対応）
- フォローアップ Q&A (`previous_interaction_id` 活用) — 完了レポートに対する「3 章をもっと詳しく」等を DR フルコンテキスト経由で扱う案

## 既知の制限
- Bot 再起動で走行中タスク・pending プランは失われる（永続化なし）
- View timeout 中の長考は再提示が必要
- Modal TextInput は Discord 仕様上 2000 文字上限
- 画像 mime は PNG 前提（他形式も `.png` で投稿）
- マルチモーダル入力は初回 create のみ。DR 側の context 保持前提（SDK 挙動は実機検証）

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)