### PR TITLE
fix: skip thought & fall back to .content for DR MAX output (#34)

### DIFF
--- a/GeminiDiscordBot.py
+++ b/GeminiDiscordBot.py
@@ -1671,10 +1671,37 @@ async def _run_deep_research(
                                     logging.exception(
                                         "Failed to decode Deep Research image %d", i
                                     )
+                            continue
+                        # Skip internal reasoning traces emitted by MAX-tier
+                        # agents (type='thought' / 'reasoning'). They are CoT,
+                        # not part of the report body.
+                        if typ in ("thought", "reasoning"):
+                            continue
+                        txt = getattr(out, "text", None)
+                        if not txt:
+                            # Fallback for Responses-style outputs where text
+                            # lives under .content[*].text instead of a flat
+                            # .text accessor.
+                            content = getattr(out, "content", None)
+                            if isinstance(content, list):
+                                collected: list[str] = []
+                                for part in content:
+                                    t = getattr(part, "text", None)
+                                    if t:
+                                        collected.append(t)
+                                if collected:
+                                    txt = "".join(collected)
+                        if txt:
+                            text_parts.append(txt)
+                            logging.info(
+                                "DR output[%d] type=%s included (len=%d)",
+                                i, typ, len(txt),
+                            )
                         else:
-                            txt = getattr(out, "text", None)
-                            if txt:
-                                text_parts.append(txt)
+                            logging.info(
+                                "DR output[%d] type=%s skipped (no text)",
+                                i, typ,
+                            )
                     result_text = "\n\n".join(text_parts).strip()
                 except Exception:
                     result_text = ""


### PR DESCRIPTION
Closes #34

## Summary
- \`DEEP_RESEARCH_AGENT=\"deep-research-max-preview-04-2026\"\` で \`!dr\` を実行すると、output types=['thought', 'text', 'image', 'text', 'text'] のような MAX 特有の shape を返す。
- 旧抽出ループは image 以外を全部同じ \`.text\` アクセスに通していたため、CoT (\`thought\`) がレポート MD に混入、または \`.text\` が None で本文が落ちる問題が発生した。
- 抽出ロジックに下記を追加:
  - \`type == \"thought\" / \"reasoning\"\` を明示スキップ
  - 非画像 output で \`.text\` が空なら \`.content[*].text\` を順に連結するフォールバック
  - 各 output に per-item INFO ログ (type, len, included/skipped)

## Design notes
- 通常版 \`deep-research-preview\` には \`thought\`/\`reasoning\` 型が来ないので挙動変化なし。
- \`.text\` が有効な output にはそのまま hit するので、通常版の text 取得も従来通り。
- 通常の \`.text\` path が効くうちは \`.content\` を見に行かない（無駄なトラバース回避）。
- 将来 \`document\` / \`file\` など別 type が来たら "skipped (no text)" ログで検知できる。

## Test plan
- [ ] \`DEEP_RESEARCH_AGENT=deep-research-preview-04-2026\` で \`!dr\` → 通常版で従来通り MD 添付 & サマリ注入
- [ ] \`DEEP_RESEARCH_AGENT=deep-research-max-preview-04-2026\` で \`!dr\` → MD が添付される、中身に CoT (thought) が含まれない
- [ ] \`journalctl\` / stderr で \`DR output[i] type=... included (len=N)\` ログを確認、思った output が全部拾えているか目視
- [ ] \`RESET\` で中断が引き続き動作

## 観察ログ（修正前）
\`\`\`
INFO root: Deep Research completed for user ...: 5 outputs, types=['thought', 'text', 'image', 'text', 'text']
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)