### PR TITLE
feat: add per-output INFO log to DR extraction (#36)

### DIFF
--- a/GeminiDiscordBot.py
+++ b/GeminiDiscordBot.py
@@ -1671,10 +1671,20 @@ async def _run_deep_research(
                                     logging.exception(
                                         "Failed to decode Deep Research image %d", i
                                     )
+                            logging.info("DR output[%d] type=%s image", i, typ)
                         else:
                             txt = getattr(out, "text", None)
                             if txt:
                                 text_parts.append(txt)
+                                logging.info(
+                                    "DR output[%d] type=%s text_len=%d included",
+                                    i, typ, len(txt),
+                                )
+                            else:
+                                logging.info(
+                                    "DR output[%d] type=%s skipped (no text)",
+                                    i, typ,
+                                )
                     result_text = "\n\n".join(text_parts).strip()
                 except Exception:
                     result_text = ""


### PR DESCRIPTION
Closes #36

## Summary
- Deep Research 完了時の output 抽出ループに 1 item ごとの INFO ログを追加（純粋な観測目的）。
- 挙動変更なし。thought/reasoning のスキップや \`.content\` フォールバックは #34 クローズの方針通り**入れない**。
- 将来 agent tier / shape が変わったときに \`journalctl\` 1 発で診断できる。

## Output example

\`\`\`
INFO root: Deep Research completed ... types=['thought', 'text', 'image', 'text', 'text']
INFO root: DR output[0] type=thought text_len=2453 included
INFO root: DR output[1] type=text text_len=12890 included
INFO root: DR output[2] type=image image
INFO root: DR output[3] type=text text_len=3210 included
INFO root: DR output[4] type=text text_len=980 included
\`\`\`

## Test plan
- [ ] 通常版 (\`deep-research-preview-04-2026\`) で \`!dr\` を軽めのトピックで実行、各 output 行が INFO ログに 1 行ずつ出ることを確認
- [ ] 既存挙動（MD 添付・サマリ注入・可視化画像）に変化なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)