### PR TITLE
[BUG] Discord メッセージ分割時の Markdown 崩れを修正 (closes #38)

### DIFF
--- a/GeminiDiscordBot.py
+++ b/GeminiDiscordBot.py
@@ -19,6 +19,8 @@ from google.genai import types
 import datetime  # Added: For timestamp
 import logging  # Added: logging module
 
+from markdown_utils import split_markdown_message  # Markdown-safe message splitting
+
 # Dictionary to store chat sessions
 chat = {}
 # Dictionary to store image generation chat sessions
@@ -954,22 +956,15 @@ async def process_cloud_file(
 
 
 async def split_and_send_messages(message_system, text, max_length):
-    """Split the message into chunks and send them, respecting the maximum length."""
-    start = 0
-    while start < len(text):
-        if len(text) - start <= max_length:
-            await message_system.channel.send(text[start:])
-            break
+    """Split the message on Markdown-safe boundaries and send each part.
 
-        end = start + max_length
-        while end > start and text[end - 1] not in " \n\r\t":
-            end -= 1
-
-        if end == start:
-            end = start + max_length
-
-        await message_system.channel.send(text[start:end].strip())
-        start = end
+    Delegates chunking to `split_markdown_message` (markdown_utils) so fenced
+    code blocks stay balanced across Discord's per-message length limit, and
+    code indentation is preserved (no per-chunk stripping).
+    """
+    for chunk in split_markdown_message(text, max_length):
+        if chunk:
+            await message_system.channel.send(chunk)
 
 
 # Removed old generate_image function

--- a/markdown_utils.py
+++ b/markdown_utils.py
@@ -1,0 +1,147 @@
+"""Markdown-safe splitting of long messages for Discord's 2000-char limit.
+
+Pure, side-effect-free helpers so they can be unit-tested without importing the
+bot (which starts Discord / constructs Vertex clients at import time).
+
+Ported verbatim from the sibling project Claude_Discordbot, PR #25
+(https://github.com/yasuhiroinoue/Claude_Discordbot/pull/25), final head SHA
+3ec8df88668d3ba4496d26699c5f5ec7b0fd42ac. The splitting logic is
+provider-independent: Gemini output is also GitHub-flavored Markdown.
+"""
+
+import re
+
+# Discord's per-message character cap. Bot callers pass MAX_DISCORD_LENGTH
+# explicitly; this default only applies to direct/test use.
+MAX_DISCORD_LENGTH = 2000
+
+
+_FENCE_RE = re.compile(r'^\s*(`{3,})')
+
+
+def _fence_open(line):
+    """Return (run_len, marker_line) if `line` opens a code fence, else None.
+
+    An opener is a line whose first non-whitespace content is a run of 3+
+    backticks (optionally followed by a language/info string).
+    """
+    m = _FENCE_RE.match(line)
+    if not m:
+        return None
+    return len(m.group(1)), line
+
+
+def _is_fence_close(line, run_len):
+    """True if `line` closes a fence opened with `run_len` backticks.
+
+    A close is a line of only backticks (>= run_len), with optional surrounding
+    whitespace and no language/info text. This is intentionally NOT a plain
+    toggle: a shorter run (e.g. ``` inside a ```` block) does not close it.
+    """
+    s = line.strip()
+    return len(s) >= run_len and bool(s) and all(c == '`' for c in s)
+
+
+def _cut_at(line, limit):
+    """Largest cut index in [1, limit] for splitting `line`, preferring a space
+    boundary so words/tokens aren't broken; falls back to a hard cut at `limit`.
+    """
+    if len(line) <= limit:
+        return len(line)
+    sp = line.rfind(' ', 1, limit)
+    return sp if sp != -1 else limit
+
+
+def split_markdown_message(text, max_length=MAX_DISCORD_LENGTH):
+    """Split `text` into <= `max_length`-char chunks without breaking fenced
+    code blocks.
+
+    When a split lands inside a ``` fence, the current chunk is closed with a
+    matching fence and the next chunk reopens it with the same info line (e.g.
+    ```python), so every message renders correctly on its own. Chunk interiors
+    are preserved verbatim (no stripping, so code indentation survives), and
+    whitespace-only chunks are dropped so Discord never receives an empty
+    message.
+    """
+    if max_length <= 0:
+        return [text] if text.strip() else []
+
+    lines = text.split('\n')
+    chunks = []
+    cur = []              # buffered lines for the current chunk
+    fence = None          # (run_len, marker_line) while inside an open fence
+    has_content = False   # cur holds real content beyond a reopened fence marker
+
+    def buffered_len():
+        return sum(len(l) for l in cur) + max(0, len(cur) - 1)
+
+    def room(close_reserve):
+        # Chars available for one more line, keeping `close_reserve` chars free
+        # (e.g. to inject a closing fence when a split lands inside a code block).
+        sep = 1 if cur else 0
+        return max_length - buffered_len() - sep - close_reserve
+
+    def flush():
+        nonlocal cur, has_content
+        pieces = list(cur)
+        if fence is not None:
+            pieces.append('`' * fence[0])          # temporary close at the split
+        chunk = '\n'.join(pieces)
+        if chunk.strip():
+            chunks.append(chunk)
+        cur = [fence[1]] if fence is not None else []   # reopen on the next chunk
+        has_content = False
+
+    def add_line(line, close_reserve, is_marker=False):
+        # `is_marker` lines (fence open/close) don't count as real content, so a
+        # chunk holding only a fence marker is never flushed on its own (which
+        # would emit an empty code block).
+        nonlocal has_content
+        if len(line) <= room(close_reserve):
+            cur.append(line)
+            has_content = has_content or not is_marker
+            return
+        if has_content:
+            flush()                                 # start a fresh chunk first
+        while len(line) > room(close_reserve):
+            r = room(close_reserve)
+            if r <= 0:                              # degenerate: markers exhaust budget
+                break
+            cut = _cut_at(line, r)
+            cur.append(line[:cut])
+            has_content = True                      # a split piece is real content
+            flush()
+            line = line[cut:]
+        cur.append(line)
+        has_content = has_content or not is_marker
+
+    for line in lines:
+        opened_now = _fence_open(line) if fence is None else None
+        closing_now = fence is not None and _is_fence_close(line, fence[0])
+        if opened_now:
+            close_reserve = 1 + opened_now[0]       # reserve for its eventual close
+            is_marker = True
+        elif closing_now:
+            close_reserve = 0                       # this line IS the real close
+            is_marker = True
+        elif fence is not None:
+            close_reserve = 1 + fence[0]            # room to inject a close if we split
+            is_marker = False
+        else:
+            close_reserve = 0
+            is_marker = False
+        add_line(line, close_reserve, is_marker)
+        if opened_now:
+            fence = opened_now
+        elif closing_now:
+            fence = None
+
+    # Final chunk: emit only if it carries real content. A trailing chunk of
+    # injected markers only (reopen marker +/- real close) would render as an
+    # empty code block, so it is dropped — the content is already in prior chunks.
+    # No closing fence is injected here: an original that ends inside an unclosed
+    # fence is mirrored faithfully.
+    tail = '\n'.join(cur)
+    if has_content and tail.strip():
+        chunks.append(tail)
+    return chunks

--- a/tests/test_markdown_utils.py
+++ b/tests/test_markdown_utils.py
@@ -1,0 +1,275 @@
+"""Unit tests for markdown_utils.split_markdown_message (Discord Markdown-safe split).
+
+Run directly (no pytest dependency needed):
+    python tests/test_markdown_utils.py
+or under pytest:
+    python -m pytest tests/test_markdown_utils.py
+
+Ports the Case0-Case8 verification strategy from Claude_Discordbot PR #25 (whose
+standalone test file was not committed there). Each chunk is validated by feeding
+it through the *same* fence state machine the splitter uses, to confirm it ends
+*closed* (not merely an even count of ```). Also checks: non-fence content is
+reconstructed in order, every chunk is <= max_length, language tags survive the
+reopen, run-length edges are respected (``` inside a ```` block is not a close),
+and the 1999/2000/2001 boundary produces no empty code block.
+"""
+
+import os
+import sys
+
+# Make the repo root importable whether run as a script (cwd/tests dir on path)
+# or under pytest, so we exercise the REAL shipped markdown_utils.
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from markdown_utils import (  # noqa: E402
+    MAX_DISCORD_LENGTH,
+    _cut_at,
+    _fence_open,
+    _is_fence_close,
+    split_markdown_message,
+)
+
+
+# --- validation helpers -------------------------------------------------------
+
+def _ends_closed(chunk):
+    """True if `chunk` ends OUTSIDE any open fence (renders as balanced Markdown).
+
+    Uses the splitter's own _fence_open / _is_fence_close, i.e. a real state
+    machine rather than a naive "count of ``` is even" heuristic.
+    """
+    fence = None
+    for line in chunk.split("\n"):
+        if fence is None:
+            opened = _fence_open(line)
+            if opened:
+                fence = opened
+        elif _is_fence_close(line, fence[0]):
+            fence = None
+    return fence is None
+
+
+def _content_lines(text):
+    """Lines that are NOT structural fence markers, per the splitter's state
+    machine. Original and injected (reopen / temp-close) markers are dropped;
+    content — including backtick-looking lines inside a wider fence — is kept.
+    """
+    out = []
+    fence = None
+    for line in text.split("\n"):
+        if fence is None:
+            opened = _fence_open(line)
+            if opened:
+                fence = opened
+                continue
+            out.append(line)
+        else:
+            if _is_fence_close(line, fence[0]):
+                fence = None
+                continue
+            out.append(line)
+    return out
+
+
+def _content_chars(text):
+    """Content characters with structural fence markers and line breaks removed,
+    so reconstruction survives hard-split lines (a mid-line cut just yields two
+    adjacent pieces that concatenate back).
+    """
+    return "".join(_content_lines(text))
+
+
+def _assert_valid(text, chunks, max_length, balanced=True):
+    for c in chunks:
+        assert c.strip(), "empty/whitespace-only chunk emitted"
+        assert len(c) <= max_length, f"chunk len {len(c)} > max_length {max_length}"
+        assert _content_chars(c).strip() != "", "empty code-block (marker-only) chunk emitted"
+    if balanced:
+        for c in chunks:
+            assert _ends_closed(c), "chunk does not end with a balanced fence"
+    else:
+        for c in chunks[:-1]:
+            assert _ends_closed(c), "non-final chunk not temp-closed at split"
+    assert _content_chars(text) == _content_chars("\n".join(chunks)), \
+        "content not reconstructed (order/characters lost)"
+
+
+def _bare_fenced(total_len):
+    """A ```-fenced block of exactly `total_len` chars: ```\\n<body>\\n``` ."""
+    body_len = total_len - 8  # len("```\n") + len("\n```")
+    assert body_len >= 0
+    return "```\n" + ("x" * body_len) + "\n```"
+
+
+# --- Case 0: helper detection -------------------------------------------------
+
+def test_case0_helpers():
+    assert _fence_open("```python") == (3, "```python")
+    assert _fence_open("   ```") == (3, "   ```")       # leading whitespace allowed
+    assert _fence_open("````") == (4, "````")
+    assert _fence_open("no fence") is None
+    assert _fence_open("``two") is None                 # only 2 backticks
+
+    assert _is_fence_close("```", 3) is True
+    assert _is_fence_close("````", 3) is True           # longer run also closes
+    assert _is_fence_close("```", 4) is False           # shorter run does NOT close
+    assert _is_fence_close("  ```  ", 3) is True         # surrounding whitespace ok
+    assert _is_fence_close("``` python", 3) is False     # info text => not a close
+    assert _is_fence_close("", 3) is False
+
+    assert _cut_at("hello world", 100) == len("hello world")  # fits, no cut
+    assert _cut_at("hello world", 8) == 5                     # cut at the space
+    assert _cut_at("helloworld", 5) == 5                      # no space => hard cut
+
+
+# --- Case 1: fenced code block split, language tag + indentation preserved ----
+
+def test_case1_code_block():
+    body = "\n".join(f"    code_line_{i}()" for i in range(60))  # 4-space indent
+    text = "```python\n" + body + "\n```"
+    max_length = 100
+    chunks = split_markdown_message(text, max_length)
+    assert len(chunks) > 1
+    _assert_valid(text, chunks, max_length)
+    for c in chunks:
+        assert c.split("\n")[0] == "```python", "language tag not preserved on reopen"
+        assert c.split("\n")[-1] == "```", "chunk not fence-closed"
+    assert any("    code_line_" in c for c in chunks), "indentation was stripped"
+
+
+# --- Case 2: inline formatting (no fences) across a split --------------------
+
+def test_case2_inline_formatting():
+    lines = [
+        f"Paragraph {i}: here is `inline_code_{i}` and **bold_{i}** with _em{i}_ text."
+        for i in range(30)
+    ]
+    text = "\n".join(lines)
+    max_length = 100
+    chunks = split_markdown_message(text, max_length)
+    assert len(chunks) > 1
+    _assert_valid(text, chunks, max_length)
+    for c in chunks:                       # single backticks never open a fence
+        for line in c.split("\n"):
+            assert _fence_open(line) is None
+
+
+# --- Case 3: hard split of one very long, space-less token -------------------
+
+def test_case3_hard_split():
+    text = "A" * 350  # one line, no spaces, no fences
+    max_length = 100
+    chunks = split_markdown_message(text, max_length)
+    assert len(chunks) == 4  # 100 + 100 + 100 + 50
+    _assert_valid(text, chunks, max_length)
+    assert "".join(chunks) == text  # exact reconstruction, nothing added/lost
+
+
+# --- Case 4: quad-fence (````), inner ``` is content, not a close ------------
+
+def test_case4_quad_fence_inner_triple():
+    inner = "\n".join(f"``` still-open {i}" for i in range(20))
+    text = "````\n" + inner + "\n````"
+    max_length = 40
+    chunks = split_markdown_message(text, max_length)
+    assert len(chunks) > 1
+    _assert_valid(text, chunks, max_length)
+    for c in chunks:
+        assert c.split("\n")[0] == "````"   # reopened with the 4-backtick run
+        assert c.split("\n")[-1] == "````"
+    assert any("still-open" in c for c in chunks)  # inner ``` survived as content
+
+
+# --- Case 5: short / empty / max_length <= 0 --------------------------------
+
+def test_case5_short_and_empty():
+    assert split_markdown_message("") == []
+    assert split_markdown_message("   ") == []
+    assert split_markdown_message("\n\n") == []
+    assert split_markdown_message("hello") == ["hello"]
+    assert split_markdown_message("hello world", 2000) == ["hello world"]
+    assert split_markdown_message("x", 0) == ["x"]     # degenerate branch
+    assert split_markdown_message("   ", 0) == []
+
+
+# --- Case 6: realistic mixed prose + code around the 2000 boundary -----------
+
+def test_case6_mixed_default_limit():
+    prose1 = "\n".join(
+        f"Intro line {i} with some explanatory text about the topic." for i in range(20)
+    )
+    code = (
+        "```python\n"
+        + "\n".join(f"    value_{i} = compute({i})" for i in range(40))
+        + "\n```"
+    )
+    prose2 = "\n".join(
+        f"Conclusion line {i} summarizing the measured results here." for i in range(20)
+    )
+    text = prose1 + "\n\n" + code + "\n\n" + prose2
+    assert len(text) > MAX_DISCORD_LENGTH
+    chunks = split_markdown_message(text, MAX_DISCORD_LENGTH)
+    assert len(chunks) >= 2
+    _assert_valid(text, chunks, MAX_DISCORD_LENGTH)
+
+
+# --- Case 7: block that fits (1999/2000) stays a single unchanged chunk ------
+
+def test_case7_boundary_single_chunk():
+    for total in (1999, 2000):
+        text = _bare_fenced(total)
+        assert len(text) == total
+        chunks = split_markdown_message(text, MAX_DISCORD_LENGTH)
+        assert chunks == [text], f"len={total} should be one unchanged chunk"
+
+
+# --- Case 8: block one char over (2001) => two chunks, no empty code block ---
+
+def test_case8_boundary_two_chunks():
+    text = _bare_fenced(2001)
+    assert len(text) == 2001
+    chunks = split_markdown_message(text, MAX_DISCORD_LENGTH)
+    assert len(chunks) == 2, "2001-char block should split into exactly two chunks"
+    _assert_valid(text, chunks, MAX_DISCORD_LENGTH)
+
+
+# --- Case 9: unclosed fence mirrored faithfully; splits inject a temp close --
+
+def test_case9_unclosed_fence_mirrored():
+    # Fits in one chunk => returned unchanged, still unclosed (faithful mirror).
+    text = "```python\nprint(1)\nprint(2)"
+    chunks = split_markdown_message(text, MAX_DISCORD_LENGTH)
+    assert chunks == [text]
+    assert not _ends_closed(chunks[-1])
+
+    # Forced to split => intermediate chunks temp-closed, last stays unclosed.
+    long_unclosed = "```python\n" + "\n".join(f"row_{i} = {i}" for i in range(80))
+    chunks = split_markdown_message(long_unclosed, 40)
+    assert len(chunks) > 1
+    _assert_valid(long_unclosed, chunks, 40, balanced=False)
+    assert not _ends_closed(chunks[-1]), "final unclosed fence should be mirrored open"
+
+
+_CASES = [
+    ("Case0 helper detection", test_case0_helpers),
+    ("Case1 code block", test_case1_code_block),
+    ("Case2 inline formatting", test_case2_inline_formatting),
+    ("Case3 hard split", test_case3_hard_split),
+    ("Case4 quad-fence w/ inner ```", test_case4_quad_fence_inner_triple),
+    ("Case5 short/empty", test_case5_short_and_empty),
+    ("Case6 mixed @2000", test_case6_mixed_default_limit),
+    ("Case7 fenced block at 1999/2000", test_case7_boundary_single_chunk),
+    ("Case8 fenced block at 2001", test_case8_boundary_two_chunks),
+    ("Case9 unclosed fence mirrored", test_case9_unclosed_fence_mirrored),
+]
+
+
+def _run_all():
+    for name, fn in _CASES:
+        fn()
+        print(f"{name}: OK")
+    print("ALL TESTS PASSED")
+
+
+if __name__ == "__main__":
+    _run_all()


### PR DESCRIPTION
## 目的 (Purpose)
長い Gemini 応答の Discord 2000 文字分割で Markdown（特にフェンス付きコードブロック）が崩れる問題を修正する（Closes #38）。

## 問題
現行 `split_and_send_messages`（`GeminiDiscordBot.py:956`）は 2000 文字境界を空白まで戻して切り、中間チャンクに `.strip()` を適用していた（最終チャンクは strip なし）。境界がフェンス（```` ``` ````）の内側に来ると閉じ記号が次メッセージへ移り両方が崩れ、`.strip()` はコードのインデント/空行を落としていた。

## 変更内容
姉妹プロジェクト **Claude_Discordbot PR #25**（merged, `[BUG]`）を移植。分割ロジックはプロバイダ非依存（Gemini 出力も GitHub Markdown）。

- **新規 `markdown_utils.py`（pure / import 副作用なし）**: `_FENCE_RE` / `_fence_open` / `_is_fence_close` / `_cut_at` / `split_markdown_message` を PR #25 の**最終 head SHA `3ec8df88668d3ba4496d26699c5f5ec7b0fd42ac` から verbatim** で移植。
  - `GeminiDiscordBot.py` は import 時に `genai.Client(...)`（`:182`/`:186`）と `bot.run(...)`（`:1805`）が走るため、bot を import する単体テストが書けない。純粋モジュール化で**実出荷コードをテスト可能**にした。
- **`GeminiDiscordBot.py`**: `from markdown_utils import split_markdown_message` を追加し、`split_and_send_messages` の中身を「算出チャンクを送るだけ」に簡素化。**シグネチャ維持**のため呼び出し 5 箇所（`355`/`465`/`492`/`949`/`1722`）は無変更。
- **`tests/test_markdown_utils.py`（committed）**: Case0–9 の単体テスト。

分割ロジック本体の不変条件（PR #25 と同一）:
- フェンス閉じは「run 長 ≥ 開き」の**バックティックのみの行**に限定（```` ``` ```` を ```` ```` ```` 内で誤 close しない）。
- close 予約は行ごと・実閉じ行は予約 0 → **収まるブロックは 1 チャンクのまま**（余分な空ブロックを出さない）。
- マーカーは content に数えず marker-only の空コードブロックを防止／`.strip()` 廃止でインデント保持／超長行はハードスプリット／未閉じフェンスは分割時のみ一時閉じ、全体としては忠実にミラー。

## 受け入れ条件（達成）
- 全チャンク `len <= 2000` / 空チャンクなし / コードインデント保持 / ```` ```python ```` の言語タグ再オープン保持 / 分割不要なら余分な空ブロックを出さない。

## 証跡 (Evidence)
- `python -m py_compile GeminiDiscordBot.py markdown_utils.py tests/test_markdown_utils.py` → OK。
- `python tests/test_markdown_utils.py` → 全 Case PASS:
```
Case0 helper detection: OK
Case1 code block: OK
Case2 inline formatting: OK
Case3 hard split: OK
Case4 quad-fence w/ inner ```: OK
Case5 short/empty: OK
Case6 mixed @2000: OK
Case7 fenced block at 1999/2000: OK
Case8 fenced block at 2001: OK
Case9 unclosed fence mirrored: OK
ALL TESTS PASSED
```
- テスト手法: 各チャンクを**フェンス状態機械に通し最終 closed 判定**（「``` 偶数」ではない）／非フェンス行の**順序込み文字列復元**／`len(chunk) <= max_length`／言語タグ保持／**run 長エッジ**（```` ```` ```` 内の ``` を close 誤検出しない）／超長行ハードスプリット復元／**空コードブロックを出さない**／境界（1999/2000 単一・2001 で 2 分割）。
- 参照 PR #25 の最終 SHA と `split_markdown_message` が byte 一致であることを read-only で確認済み。

## スコープ外（限界として明記）
- インラインコード/太字/斜体/リンク等のフル Markdown 平衡（行境界分割でほぼ回避）。超長行のハードスプリットがインライン `` ` `` を跨ぐ稀ケース。

## 補足
- `tests/` にテストを**コミット**（Codex レビュー指摘 P1）。`pytest` 未導入環境でも `python tests/test_markdown_utils.py` で実行可能（pytest があれば discover も可能）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
