### PR TITLE
[BUG] Deep Research 出力抽出を google-genai 2.10.0 に対応 (closes #40)

### DIFF
--- a/GeminiDiscordBot.py
+++ b/GeminiDiscordBot.py
@@ -5,7 +5,6 @@ import aiohttp
 import io
 
 import asyncio
-import base64
 import magic
 import discord
 import tempfile
@@ -20,6 +19,7 @@ import datetime  # Added: For timestamp
 import logging  # Added: logging module
 
 from markdown_utils import split_markdown_message  # Markdown-safe message splitting
+from dr_utils import extract_dr_result  # Deep Research result extraction (2.10.0 schema)
 
 # Dictionary to store chat sessions
 chat = {}
@@ -89,6 +89,12 @@ DEEP_RESEARCH_MAX_CONCURRENT = int(os.getenv("DEEP_RESEARCH_MAX_CONCURRENT", "2"
 DEEP_RESEARCH_POLL_SECONDS = int(os.getenv("DEEP_RESEARCH_POLL_SECONDS", "20"))
 DEEP_RESEARCH_TIMEOUT_SECONDS = int(os.getenv("DEEP_RESEARCH_TIMEOUT_SECONDS", "3900"))
 _dr_global_semaphore = asyncio.Semaphore(DEEP_RESEARCH_MAX_CONCURRENT)
+
+# Terminal Interactions API statuses that end polling (google-genai 2.10.0
+# InteractionStatus). "completed" is the success case; the rest are non-success
+# terminal states. Without the latter, a cancelled/incomplete/budget_exceeded
+# job would keep polling until DEEP_RESEARCH_TIMEOUT_SECONDS.
+_DR_TERMINAL_STATUSES = ("completed", "failed", "cancelled", "incomplete", "budget_exceeded")
 
 # Load the environment variable for enabling/disabling commands
 IMG_COMMANDS_ENABLED = os.getenv("IMG_COMMANDS_ENABLED", "False").lower() == "true"
@@ -1615,7 +1621,7 @@ async def _run_deep_research(
                         await message.add_reaction("❌")
                     return
 
-                if interaction.status in ("completed", "failed"):
+                if interaction.status in _DR_TERMINAL_STATUSES:
                     break
 
                 if time.monotonic() - last_heartbeat >= 60:
@@ -1638,53 +1644,22 @@ async def _run_deep_research(
 
             if interaction.status == "completed":
                 try:
-                    outputs = interaction.outputs or []
+                    result_text, image_bytes = extract_dr_result(interaction)
+                    image_files = [
+                        discord.File(io.BytesIO(b), filename=f"dr_viz_{i}.png")
+                        for i, b in enumerate(image_bytes)
+                    ]
                     logging.info(
-                        "Deep Research completed for user %s (planning_mode=%s): %d outputs, types=%s",
-                        user_id, planning_mode, len(outputs),
-                        [getattr(o, "type", "?") for o in outputs],
+                        "Deep Research completed for user %s (planning_mode=%s): "
+                        "text_len=%d, images=%d",
+                        user_id, planning_mode, len(result_text), len(image_files),
                     )
-                    text_parts: list[str] = []
-                    image_files: list[discord.File] = []
-                    for i, out in enumerate(outputs):
-                        typ = getattr(out, "type", None)
-                        if typ == "image":
-                            raw = getattr(out, "data", None)
-                            if raw:
-                                try:
-                                    img_bytes = (
-                                        base64.b64decode(raw)
-                                        if isinstance(raw, str) else bytes(raw)
-                                    )
-                                    image_files.append(
-                                        discord.File(
-                                            io.BytesIO(img_bytes),
-                                            filename=f"dr_viz_{i}.png",
-                                        )
-                                    )
-                                except Exception:
-                                    logging.exception(
-                                        "Failed to decode Deep Research image %d", i
-                                    )
-                            logging.info("DR output[%d] type=%s image", i, typ)
-                        else:
-                            txt = getattr(out, "text", None)
-                            if txt:
-                                text_parts.append(txt)
-                                logging.info(
-                                    "DR output[%d] type=%s text_len=%d included",
-                                    i, typ, len(txt),
-                                )
-                            else:
-                                logging.info(
-                                    "DR output[%d] type=%s skipped (no text)",
-                                    i, typ,
-                                )
-                    result_text = "\n\n".join(text_parts).strip()
                 except Exception:
+                    # extract_dr_result already skips bad images internally; this
+                    # only guards against an unexpected Interaction shape.
                     result_text = ""
                     image_files = []
-                    logging.exception("Failed to extract result for user %s", user_id)
+                    logging.exception("Failed to extract Deep Research result for user %s", user_id)
 
                 if not result_text:
                     await ack.edit(
@@ -1760,15 +1735,17 @@ async def _run_deep_research(
                         ),
                         view=None,
                     )
-            else:  # failed
-                error_msg = getattr(interaction, "error", "<unknown>")
-                await message.channel.send(f"❌ {ack_prefix} failed: {error_msg}")
+            else:  # non-success terminal state: failed / cancelled / incomplete / budget_exceeded
+                # Interaction has no top-level `.error` field in google-genai 2.10.0,
+                # so surface the terminal status instead of a always-"<unknown>" error.
+                status = getattr(interaction, "status", "unknown")
+                await message.channel.send(f"❌ {ack_prefix} did not complete (status: {status})")
                 await ack.edit(
                     content=(
-                        f"❌ {ack_prefix} failed ({elapsed_min}m)\n"
+                        f"❌ {ack_prefix} did not complete ({elapsed_min}m)\n"
                         f"Topic: **{topic}**\n"
                         f"id: `{interaction_id}`\n"
-                        f"error: {error_msg}"
+                        f"status: {status}"
                     ),
                     view=None,
                 )

--- a/dr_utils.py
+++ b/dr_utils.py
@@ -1,0 +1,88 @@
+"""Pure helpers for extracting results from a Gemini Interactions API response.
+
+Kept import-side-effect-free (no Discord/Vertex initialization) so it can be
+unit-tested without importing GeminiDiscordBot.py, mirroring markdown_utils.py.
+
+Targets the google-genai 2.10.0 Interaction schema: a completed interaction
+exposes its result via `interaction.output_text` and
+`interaction.steps[].content[]` (model_output steps → text/image content, with
+images carrying base64 in `ImageContent.data`). The pre-2.10 `interaction.outputs`
+field was removed. Only duck-typed attribute access (`getattr`) is used here, so
+this works against the real SDK models without importing SDK internals.
+"""
+
+import base64
+import logging
+
+
+def _current_turn_steps(steps):
+    """Return only the steps of the latest turn: everything after the last
+    `user_input` step.
+
+    Deep Research chains interactions via `previous_interaction_id`, so `steps`
+    can contain earlier turns. Restricting to the segment after the final
+    `user_input` mirrors the SDK's `output_text` semantics and prevents an older
+    turn's report/visualizations from leaking into the current result.
+    """
+    if not steps:
+        return []
+    start = 0
+    for idx in range(len(steps) - 1, -1, -1):
+        if getattr(steps[idx], "type", None) == "user_input":
+            start = idx + 1
+            break
+    return steps[start:]
+
+
+def _decode_image(data):
+    """Decode base64 str / bytes to raw bytes, or return None if undecodable."""
+    if not data:
+        return None
+    try:
+        return base64.b64decode(data) if isinstance(data, str) else bytes(data)
+    except Exception as exc:
+        logging.warning("Skipping undecodable Deep Research image: %s", exc)
+        return None
+
+
+def extract_dr_result(interaction):
+    """Extract ``(report_text, image_bytes_list)`` from a completed Interaction.
+
+    - text: prefer ``interaction.output_text``; if empty, concatenate text
+      content from the latest turn's ``model_output`` steps.
+    - images: raw bytes decoded from image content in the latest turn's
+      ``model_output`` steps. A single undecodable image is skipped and never
+      affects the text or the other images (text and image extraction are
+      independent).
+
+    Returns ``("", [])`` when nothing usable is present. `thought` and tool
+    steps are ignored (only `model_output` steps are considered).
+    """
+    steps = _current_turn_steps(getattr(interaction, "steps", None))
+
+    # --- text ---
+    text = (getattr(interaction, "output_text", None) or "").strip()
+    if not text:
+        parts = []
+        for step in steps:
+            if getattr(step, "type", None) != "model_output":
+                continue
+            for content in (getattr(step, "content", None) or []):
+                if getattr(content, "type", None) == "text":
+                    t = getattr(content, "text", None)
+                    if t:
+                        parts.append(t)
+        text = "\n\n".join(parts).strip()
+
+    # --- images (independent of text; per-image failures are skipped) ---
+    images = []
+    for step in steps:
+        if getattr(step, "type", None) != "model_output":
+            continue
+        for content in (getattr(step, "content", None) or []):
+            if getattr(content, "type", None) == "image":
+                decoded = _decode_image(getattr(content, "data", None))
+                if decoded is not None:
+                    images.append(decoded)
+
+    return text, images

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 discord.py
 python-dotenv
-google-genai
+google-genai>=2.10.0,<2.11.0
 aiohttp
 python-magic

--- a/tests/test_dr_utils.py
+++ b/tests/test_dr_utils.py
@@ -1,0 +1,229 @@
+"""Unit tests for dr_utils.extract_dr_result (Deep Research result extraction).
+
+Run directly (no pytest dependency needed) — use the venv that has google-genai:
+    /home/yasuhiro_inoue/disco/bin/python tests/test_dr_utils.py
+or under pytest:
+    /home/yasuhiro_inoue/disco/bin/python -m pytest tests/test_dr_utils.py
+
+Two layers:
+- Primary: duck-typed fakes (SimpleNamespace). Deterministic, no SDK dependency.
+  extract_dr_result uses only getattr, so fakes faithfully model its contract.
+- Secondary: a guarded smoke test built from the REAL SDK models. Those live in
+  the PRIVATE path google.genai._gaos.types.interactions (they are NOT in public
+  google.genai.types), so the imports are wrapped and the test SKIPS if the path
+  is unavailable — degrading to skip rather than error on a future SDK reshuffle.
+"""
+
+import base64
+import os
+import sys
+from types import SimpleNamespace as NS
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from dr_utils import extract_dr_result  # noqa: E402
+
+_PYTEST = "pytest" in sys.modules
+
+
+class _Skip(Exception):
+    """Raised to skip a test under the dependency-free direct runner."""
+
+
+def _skip(msg):
+    # Under pytest, use its native skip; under the direct __main__ runner, raise
+    # _Skip (never call pytest.skip when pytest isn't driving — it would error).
+    if _PYTEST:
+        import pytest
+        pytest.skip(msg)
+    raise _Skip(msg)
+
+
+# --- fixtures / fakes ---------------------------------------------------------
+
+PNG = b"\x89PNG\r\n\x1a\n-fake-image-bytes-"
+PNG_B64 = base64.b64encode(PNG).decode()
+PNG2 = b"second-image-bytes"
+PNG2_B64 = base64.b64encode(PNG2).decode()
+
+
+def _text(t):
+    return NS(type="text", text=t)
+
+
+def _image(data):
+    return NS(type="image", data=data)
+
+
+def _model_output(*content):
+    return NS(type="model_output", content=list(content))
+
+
+def _user_input():
+    return NS(type="user_input", content=[])
+
+
+def _thought(t):
+    return NS(type="thought", content=[_text(t)])
+
+
+def _interaction(output_text=None, steps=None):
+    return NS(output_text=output_text, steps=steps)
+
+
+# --- Case 1: output_text preferred; images pulled from steps -----------------
+
+def test_case1_output_text_preferred():
+    inter = _interaction(
+        output_text="Report body",
+        steps=[_model_output(_text("fallback-not-used"), _image(PNG_B64))],
+    )
+    text, images = extract_dr_result(inter)
+    assert text == "Report body"
+    assert images == [PNG]
+
+
+# --- Case 2: output_text absent => concat current-turn model_output text ------
+
+def test_case2_steps_text_fallback():
+    inter = _interaction(
+        output_text=None,
+        steps=[_model_output(_text("A"), _text("B"))],
+    )
+    text, images = extract_dr_result(inter)
+    assert text == "A\n\nB"
+    assert images == []
+    # whitespace-only output_text also triggers the fallback
+    inter2 = _interaction(output_text="   ", steps=[_model_output(_text("real"))])
+    assert extract_dr_result(inter2)[0] == "real"
+
+
+# --- Case 3: multiple images (str + bytes data) ------------------------------
+
+def test_case3_multiple_images():
+    inter = _interaction(
+        output_text="x",
+        steps=[_model_output(_image(PNG_B64), _image(PNG2))],  # base64 str + raw bytes
+    )
+    _, images = extract_dr_result(inter)
+    assert images == [PNG, PNG2]
+
+
+# --- Case 4: no images -------------------------------------------------------
+
+def test_case4_no_images():
+    inter = _interaction(output_text="only text", steps=[_model_output(_text("hi"))])
+    text, images = extract_dr_result(inter)
+    assert text == "only text"
+    assert images == []
+
+
+# --- Case 5: thought / tool steps ignored ------------------------------------
+
+def test_case5_non_model_output_ignored():
+    inter = _interaction(
+        output_text=None,
+        steps=[
+            _thought("private reasoning that must not leak"),
+            NS(type="google_search_call", content=[_text("tool noise")]),
+            _model_output(_text("real answer")),
+        ],
+    )
+    text, images = extract_dr_result(inter)
+    assert text == "real answer"
+    assert images == []
+
+
+# --- Case 6: chained interaction — only the latest turn counts (P2 scoping) ---
+
+def test_case6_current_turn_scoping():
+    inter = _interaction(
+        output_text=None,
+        steps=[
+            _model_output(_text("OLD turn"), _image(PNG_B64)),   # before user_input
+            _user_input(),
+            _model_output(_text("NEW turn"), _image(PNG2_B64)),  # current turn
+        ],
+    )
+    text, images = extract_dr_result(inter)
+    assert text == "NEW turn"
+    assert images == [PNG2]
+
+
+# --- Case 7: one undecodable image skipped; text + other images survive ------
+
+def test_case7_bad_image_isolated():
+    inter = _interaction(
+        output_text="report",
+        steps=[_model_output(_image("a"), _image(PNG_B64))],  # "a": invalid base64
+    )
+    text, images = extract_dr_result(inter)
+    assert text == "report"          # text unaffected
+    assert images == [PNG]           # only the decodable image survives
+
+
+# --- Case 8: empty completed => ("", []) -------------------------------------
+
+def test_case8_empty():
+    assert extract_dr_result(_interaction(output_text=None, steps=None)) == ("", [])
+    assert extract_dr_result(_interaction(output_text="", steps=[])) == ("", [])
+
+
+# --- Case 9: guarded real-SDK smoke test -------------------------------------
+
+def _real_sdk_types():
+    try:
+        from google.genai._gaos.types.interactions.interaction import Interaction
+        from google.genai._gaos.types.interactions.modeloutputstep import ModelOutputStep
+        from google.genai._gaos.types.interactions.textcontent import TextContent
+        from google.genai._gaos.types.interactions.imagecontent import ImageContent
+        return Interaction, ModelOutputStep, TextContent, ImageContent
+    except ImportError:
+        return None
+
+
+def test_case9_real_sdk_smoke():
+    types_ = _real_sdk_types()
+    if types_ is None:
+        _skip("private google.genai._gaos.types.interactions not importable")
+    Interaction, ModelOutputStep, TextContent, ImageContent = types_
+    inter = Interaction(
+        status="completed",
+        output_text="Real report",
+        steps=[ModelOutputStep(content=[TextContent(text="Real report"),
+                                        ImageContent(data=PNG_B64)])],
+    )
+    text, images = extract_dr_result(inter)
+    assert text == "Real report"
+    assert images == [PNG]
+
+
+_CASES = [
+    ("Case1 output_text preferred", test_case1_output_text_preferred),
+    ("Case2 steps text fallback", test_case2_steps_text_fallback),
+    ("Case3 multiple images", test_case3_multiple_images),
+    ("Case4 no images", test_case4_no_images),
+    ("Case5 thought/tool ignored", test_case5_non_model_output_ignored),
+    ("Case6 current-turn scoping", test_case6_current_turn_scoping),
+    ("Case7 bad image isolated", test_case7_bad_image_isolated),
+    ("Case8 empty completed", test_case8_empty),
+    ("Case9 real-SDK smoke", test_case9_real_sdk_smoke),
+]
+
+
+def _run_all():
+    passed = skipped = 0
+    for name, fn in _CASES:
+        try:
+            fn()
+        except _Skip as e:
+            print(f"{name}: SKIPPED ({e})")
+            skipped += 1
+            continue
+        print(f"{name}: OK")
+        passed += 1
+    print(f"ALL TESTS PASSED ({passed} passed, {skipped} skipped)")
+
+
+if __name__ == "__main__":
+    _run_all()


### PR DESCRIPTION
## 目的 (Purpose)
Deep Research の出力抽出が **google-genai 2.10.0** で壊れている問題を修正する（Closes #40）。「Google のドキュメントに沿っているか」の検証中に発見。

## 問題
`_run_deep_research` は完了分岐で `interaction.outputs` を参照するが、2.10.0 の `Interaction` にこのフィールドは無く **`AttributeError`** を送出する。直後の `except Exception` に握られて `result_text=""` になり、**常に「⚠️ completed but returned empty output」を表示してレポート本文と可視化画像を破棄**していた（＝ DR 実質機能停止）。

実機確認（`/home/yasuhiro_inoue/disco`, google-genai 2.10.0）:
```
Interaction(status="completed").outputs
  -> AttributeError: 'Interaction' object has no attribute 'outputs'
hasattr(..., "steps")=True / "output_text"=True / "output_image"=True
```
2.10.0 では結果は `interaction.output_text` および `interaction.steps[].content[]`（`model_output` step → `text`/`image` content、画像は `ImageContent.data` に base64）に格納される。

根本原因: `requirements.txt` の `google-genai` が**無指定**で、SDK アップグレードによりレスポンススキーマ（`outputs` → `steps`/`output_text`）が黙って変わった。

## 変更内容
- **新規 `dr_utils.py`（pure / import 副作用なし）** に `extract_dr_result(interaction) -> (text, list[bytes])` を実装。`markdown_utils.py` と同じく、bot を import せず単体テスト可能。
  - **current-turn scoping**: `previous_interaction_id` chain で `steps` に過去ターンが混ざるため、**最後の `user_input` 以降**の step のみ対象（SDK の `output_text` と同義）。
  - text: `interaction.output_text` を優先、無ければ current-turn の `model_output` text content を連結。
  - images: current-turn の `model_output` image content を base64 デコード。**1 枚のデコード失敗は skip し text／他画像に影響させない**。
  - duck-typed（`getattr` のみ）で SDK 内部に依存しない。
- **`GeminiDiscordBot.py`**: `extract_dr_result` を使うよう完了分岐を差し替え（−50 行）。未使用の `import base64` を削除。
  - poll ループの終了判定に終端状態 `cancelled`/`incomplete`/`budget_exceeded` を追加（従来 `completed`/`failed` のみ→それ以外は timeout まで空転）。
  - 失敗分岐の `interaction.error`（2.10.0 に存在しない）を **status 提示**に修正（従来は常に `<unknown>`）。
- **`requirements.txt`**: `google-genai>=2.10.0,<2.11.0` に固定（次 minor での再スキーマ変更を防止。厳密再現なら `==2.10.0`）。
- **`tests/test_dr_utils.py`（committed）**: duck-typed fake による決定的テスト（Case1–8）＋ **real-SDK smoke test（Case9）**。

## 受け入れ条件（達成）
- output_text 優先 / steps fallback / 複数画像 / 画像なし / thought・tool step 無視 / **chained interaction の過去ターン無視** / 壊れた画像 skip / empty completed。

## 証跡 (Evidence)
`/home/yasuhiro_inoue/disco/bin/python`（google-genai 2.10.0）:
- `py_compile GeminiDiscordBot.py dr_utils.py tests/test_dr_utils.py tests/test_markdown_utils.py` → OK
- `python tests/test_dr_utils.py`:
```
Case1 output_text preferred: OK
Case2 steps text fallback: OK
Case3 multiple images: OK
Case4 no images: OK
Case5 thought/tool ignored: OK
Case6 current-turn scoping: OK
Case7 bad image isolated: OK
Case8 empty completed: OK
Case9 real-SDK smoke: OK
ALL TESTS PASSED (9 passed, 0 skipped)
```
  - **Case9 は実際の `google.genai._gaos.types.interactions` の `Interaction`/`ModelOutputStep`/`TextContent`/`ImageContent` を構築して検証**（0 skipped = private import 経路が 2.10.0 で有効）。private import 不可時は skip（直接実行では `pytest.skip` を呼ばない）。
- 既存 `tests/test_markdown_utils.py` も PASS（回帰なし）。

## 補足（検証で確認済み・準拠している箇所）
- Interactions `create(agent, input, agent_config, background, store, previous_interaction_id)` 各パラメータ、`agent_config`（`type`/`visualization`/`collaborative_planning`）、`SafetySetting(threshold="OFF")`、`Tool(google_search=...)`、`aio.chats`、`Part.from_bytes`、画像生成 config — いずれも 2.10.0／公式 docs に準拠。今回の破損は DR 出力抽出のみ。

## スコープ外
- DR 呼び出しの `client.aio.interactions` への移行（async 版は存在するが現状の `asyncio.to_thread` で動作。別 Issue）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
